### PR TITLE
Fixing check workflow names and names

### DIFF
--- a/manual_tests/behaviors/apply_on_update.py
+++ b/manual_tests/behaviors/apply_on_update.py
@@ -10,7 +10,8 @@ TEST_NAME = __name__
 
 
 def test(pr: tacos_demo.PR, workdir: Path) -> None:
-    assert pr.check("terraform_lock").wait().success
+    # TODO: use slice name
+    assert pr.check("Terraform Lock", "tacos-gha / main").wait().success
 
     pr.approve()
     assert pr.approved()
@@ -18,5 +19,5 @@ def test(pr: tacos_demo.PR, workdir: Path) -> None:
     # the taco-apply label causes the plan to become clean:
     assert tf.plan_dirty(workdir)
     since = pr.add_label(":taco::apply")
-    assert pr.check("terraform_apply").wait(since).success
+    assert pr.check("Terraform Apply", "tacos-gha / main").wait(since).success
     assert tf.plan_clean(workdir)

--- a/manual_tests/behaviors/force_unlock_on_dirty.py
+++ b/manual_tests/behaviors/force_unlock_on_dirty.py
@@ -11,13 +11,14 @@ TEST_NAME = __name__
 
 @pytest.mark.xfail(raises=XFailed)
 def test(pr: tacos_demo.PR) -> None:
-    assert pr.check("terraform_lock").wait().success
+    # TODO: use slice name
+    assert pr.check("Terraform Lock", "tacos-gha / main").wait().success
 
     since = pr.add_label(":taco::apply")
-    assert pr.check("terraform_apply").wait(since).success
+    assert pr.check("Terraform Apply", "tacos-gha / main").wait(since).success
 
     since = pr.add_label(":taco::unlock")
-    assert pr.check("terraform_unlock").wait(since).success
+    assert pr.check("Terraform Unlock", "tacos-gha / main").wait(since).success
     try:
         assert (
             "WARNING: Unlocked while applied but not merged!"

--- a/manual_tests/behaviors/force_unlock_on_happy_path.py
+++ b/manual_tests/behaviors/force_unlock_on_happy_path.py
@@ -11,10 +11,11 @@ TEST_NAME = __name__
 
 @pytest.mark.xfail(raises=XFailed)
 def test(pr: tacos_demo.PR) -> None:
-    assert pr.check("terraform_lock").wait().success
+    # TODO: use slice name
+    assert pr.check("Terraform Lock", "tacos-gha / main").wait().success
 
     since = pr.add_label(":taco::unlock")
-    assert pr.check("terraform_unlock").wait(since).success
+    assert pr.check("Terraform Unlock", "terraform_unlock").wait(since).success
 
     try:
         assert "INFO: Main branch clean, unlock successful." in pr.comments(

--- a/manual_tests/behaviors/lock_on_pr.py
+++ b/manual_tests/behaviors/lock_on_pr.py
@@ -10,7 +10,8 @@ def test(pr: tacos_demo.PR, git_clone: gh.repo.Local) -> None:
     for s in slices:
         assert (
             pr.check(
-                f"terraform_lock ({(slices.workdir / s).relative_to(git_clone.path)})"
+                "Terraform Lock",
+                f"tacos-gha / main ({(slices.workdir / s).relative_to(git_clone.path)})"
             )
             .wait()
             .success

--- a/manual_tests/behaviors/unlock_on_merge.py
+++ b/manual_tests/behaviors/unlock_on_merge.py
@@ -11,11 +11,12 @@ TEST_NAME = __name__
 
 @pytest.mark.xfail(raises=XFailed)
 def test(pr: tacos_demo.PR) -> None:
-    assert pr.check("terraform_lock").wait().success
+    # TODO: use slice name
+    assert pr.check("Terraform Lock", "tacos-gha / main").wait().success
 
     since = pr.approve()
     assert pr.approved()
 
     pr.merge()
 
-    assert pr.check("terraform_unlock").wait(since, timeout=6).success
+    assert pr.check("Terraform Unlock", "tacos-gha / main").wait(since, timeout=6).success

--- a/manual_tests/lib/gh/check.py
+++ b/manual_tests/lib/gh/check.py
@@ -11,6 +11,7 @@ from lib.sh import sh
 from .types import URL
 from .types import CheckName
 from .types import Generator
+from .types import WorkflowName
 
 if TYPE_CHECKING:
     from .check_run import CheckRun
@@ -41,6 +42,7 @@ def get_runs_json(pr_url: URL) -> Generator[json.Value]:
 @dataclass(frozen=True)
 class Check:
     pr: PR
+    workflow_name: WorkflowName
     name: CheckName
 
     def get_runs(self) -> Generator[CheckRun]:
@@ -49,7 +51,7 @@ class Check:
 
         for obj in get_runs_json(self.pr.url):
             run = CheckRun.from_json(obj)
-            if run.name == self.name:
+            if run.workflowName == self.workflow_name and run.name == self.name:
                 yield run
 
     def latest(self) -> CheckRun:

--- a/manual_tests/lib/gh/pr.py
+++ b/manual_tests/lib/gh/pr.py
@@ -19,6 +19,7 @@ from .types import URL
 from .types import Branch
 from .types import CheckName
 from .types import Label
+from .types import WorkflowName
 
 Comment = str  # a PR comment
 
@@ -148,10 +149,10 @@ class PR:
                 result.append(comment["body"])
         return tuple(result)
 
-    def check(self, check_name: CheckName) -> Check:
+    def check(self, workflow_name: WorkflowName, check_name: CheckName) -> Check:
         from .check import Check
 
-        return Check(self, check_name)
+        return Check(self, workflow_name, check_name)
 
     @classmethod
     def from_branch(cls, branch: Branch, since: datetime) -> Self:

--- a/manual_tests/lib/gh/types.py
+++ b/manual_tests/lib/gh/types.py
@@ -8,3 +8,4 @@ Branch = object
 Message = object
 Label = str
 CheckName = str
+WorkflowName = str

--- a/manual_tests/lib/tacos_demo.py
+++ b/manual_tests/lib/tacos_demo.py
@@ -79,7 +79,7 @@ class PR(gh.PR):
         if since is None:
             since = self.since
 
-        assert self.check("terraform_plan").wait(since).success
+        assert self.check("Terraform Plan", "tacos-gha / main").wait(since).success
         plan = [
             comment
             for comment in self.comments(since)

--- a/manual_tests/scenarios/abandon_a_branch.py
+++ b/manual_tests/scenarios/abandon_a_branch.py
@@ -15,7 +15,7 @@ def test(pr: tacos_demo.PR) -> None:
     assert pr.approved()
 
     since = pr.add_label(":taco::apply")
-    assert pr.check("terraform_apply").wait(since).success
+    assert pr.check("Terraform Apply", "tacos-gha / main").wait(since).success
 
     sh.banner("For various reasons, the PR is not merged. Time passes")
     # TODO: there should be a better way of simulating the PR being marked as stale.
@@ -23,7 +23,7 @@ def test(pr: tacos_demo.PR) -> None:
 
     sh.banner("An attempt is made to notify the PR owner")
     try:
-        assert pr.check("notify_owner").wait(since).success
+        assert pr.check("Notify Owner", "notify_owner").wait(since).success
     except AssertionError:
         raise XFailed("notify_owner action does not exist")
 
@@ -32,4 +32,4 @@ def test(pr: tacos_demo.PR) -> None:
     since = pr.add_label(":taco::abandoned")
 
     sh.banner("An attempt is made to notify other users of the repo")
-    assert pr.check("notify_collaborators").wait(since).success
+    assert pr.check("Notify Collaborators", "notify_collaborators").wait(since).success

--- a/manual_tests/scenarios/feature_branch_happy_path.py
+++ b/manual_tests/scenarios/feature_branch_happy_path.py
@@ -16,7 +16,7 @@ def apply(pr: tacos_demo.PR, xfails: XFails) -> None:
     # the taco-apply label causes the plan to become clean:
     assert tf.plan_dirty(pr.slices.workdir)
     since = pr.add_label(":taco::apply")
-    assert pr.check("terraform_apply").wait(since).success
+    assert pr.check("Terraform Apply", "tacos-gha / main").wait(since).success
 
     try:
         assert tf.plan_clean(pr.slices.workdir)


### PR DESCRIPTION
When we updated the shared workflows we broke the check names. We can further improve these to clean up repetition down the road, this is just to get things working again.