### PR TITLE
feat(plan) Allow the plan workflow to run when the :tacos::plan label is added

### DIFF
--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -66,9 +66,11 @@ jobs:
   tacos_plan:
     # note: we want to plan draft PRs, too
     if: |
-      github.event.label.name == ':taco::plan'
+      false
+      || github.event.label.name == ':taco::plan'
       || (
-        github.event_name == 'pull_request'
+        true
+        && github.event_name == 'pull_request'
         && contains(fromJson('["opened", "synchronize", "reopened"]'), github.event.action)
       )
     needs: [determine-tf-root-modules]

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -124,6 +124,6 @@ jobs:
   reset-label:
     uses: ./.github/workflows/reset-label.yml
     with:
-      label: ":taco::apply"
+      label: ":taco::plan"
       tacos_gha_repo: ${{inputs.tacos_gha_repo}}
       tacos_gha_ref: ${{inputs.tacos_gha_ref}}

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -66,13 +66,10 @@ jobs:
   tacos_plan:
     # note: we want to plan draft PRs, too
     if: |
-      true
-      && (
-        github.event.label.name == ':taco::plan'
-        || (
-          github.event_name == 'pull_request'
-          && github.event.action == 'reopened'
-        )
+      github.event.label.name == ':taco::plan'
+      || (
+        github.event_name == 'pull_request'
+        && contains(['opened', 'synchronize', 'reopened'], github.event.action)
       )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -67,7 +67,11 @@ jobs:
     # note: we want to plan draft PRs, too
     if: |
       true
-      && github.event.label.name == ':taco::plan'
+      && (
+        github.event.label.name == ':taco::plan'
+        || (
+          github.event_name == 'pull_request'
+        )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -69,7 +69,7 @@ jobs:
       github.event.label.name == ':taco::plan'
       || (
         github.event_name == 'pull_request'
-        && contains(('opened' 'synchronize' 'reopened'), github.event.action)
+        && contains(fromJson('["opened", "synchronize", "reopened"]'), github.event.action)
       )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -69,7 +69,7 @@ jobs:
       true
       && (
         github.event.label.name == ':taco::plan'
-        || github.event.action in ('opened', 'synchronize', 'reopened')
+        || github.event.action == 'reopened'
       )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -118,10 +118,3 @@ jobs:
 
   # FIXME: we need a fan-in summary
   # summary:
-  
-  reset-label:
-    uses: ./.github/workflows/reset-label.yml
-    with:
-      label: ":taco::plan"
-      tacos_gha_repo: ${{inputs.tacos_gha_repo}}
-      tacos_gha_ref: ${{inputs.tacos_gha_ref}}

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -118,3 +118,10 @@ jobs:
 
   # FIXME: we need a fan-in summary
   # summary:
+  
+  reset-label:
+    uses: ./.github/workflows/reset-label.yml
+    with:
+      label: ":taco::plan"
+      tacos_gha_repo: ${{inputs.tacos_gha_repo}}
+      tacos_gha_ref: ${{inputs.tacos_gha_ref}}

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -67,12 +67,8 @@ jobs:
     # note: we want to plan draft PRs, too
     if: |
       false
+      || github.event_name != 'label'
       || github.event.label.name == ':taco::plan'
-      || (
-        true
-        && github.event_name == 'pull_request'
-        && contains(fromJson('["opened", "synchronize", "reopened"]'), github.event.action)
-      )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -130,3 +130,13 @@ jobs:
       label: ":taco::plan"
       tacos_gha_repo: ${{inputs.tacos_gha_repo}}
       tacos_gha_ref: ${{inputs.tacos_gha_ref}}
+
+  printJob:    
+    name: Print event
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: |
+        echo "$GITHUB_CONTEXT"

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -69,9 +69,8 @@ jobs:
       true
       && (
         github.event.label.name == ':taco::plan'
-        || (
-          github.event_name == 'pull_request'
-        )
+        || github.event_name == 'pull_request'
+      )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -65,7 +65,9 @@ jobs:
 
   tacos_plan:
     # note: we want to plan draft PRs, too
-
+    if: |
+      true
+      && github.event.label.name == ':taco::plan'
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest
     permissions:
@@ -118,3 +120,10 @@ jobs:
 
   # FIXME: we need a fan-in summary
   # summary:
+
+  reset-label:
+    uses: ./.github/workflows/reset-label.yml
+    with:
+      label: ":taco::apply"
+      tacos_gha_repo: ${{inputs.tacos_gha_repo}}
+      tacos_gha_ref: ${{inputs.tacos_gha_ref}}

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -69,7 +69,7 @@ jobs:
       github.event.label.name == ':taco::plan'
       || (
         github.event_name == 'pull_request'
-        && contains(['opened', 'synchronize', 'reopened'], github.event.action)
+        && contains(('opened' 'synchronize' 'reopened'), github.event.action)
       )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -69,7 +69,7 @@ jobs:
       true
       && (
         github.event.label.name == ':taco::plan'
-        || github.event_name == 'pull_request'
+        || github.event.action in ('opened', 'synchronize', 'reopened')
       )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -69,7 +69,10 @@ jobs:
       true
       && (
         github.event.label.name == ':taco::plan'
-        || github.event.action == 'reopened'
+        || (
+          github.event_name == 'pull_request'
+          && github.event.action == 'reopened'
+        )
       )
     needs: [determine-tf-root-modules]
     runs-on: ubuntu-latest
@@ -130,13 +133,3 @@ jobs:
       label: ":taco::plan"
       tacos_gha_repo: ${{inputs.tacos_gha_repo}}
       tacos_gha_ref: ${{inputs.tacos_gha_ref}}
-
-  printJob:    
-    name: Print event
-    runs-on: ubuntu-latest
-    steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: |
-        echo "$GITHUB_CONTEXT"


### PR DESCRIPTION
We want to run the plan operation when the plan label is added and remove it automatically as we do for apply.

I am assuming we want to keep the control of the events that trigger this action in the tacos-gha code and not in the workflows that use the actions.
That implies the condition on the event is here and not in the ops repo. 