### PR TITLE
fix(unlock) Fix the initialization of the unlock action.

### DIFF
--- a/.github/workflows/tacos_unlock.yml
+++ b/.github/workflows/tacos_unlock.yml
@@ -49,20 +49,6 @@ jobs:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
           path: tacos-gha
-      - name: tell TF username and PR
-        uses: ./tacos-gha/.github/actions/set-username-and-hostname
-      - name: environment config
-        run: |
-          "$TACOS_GHA_HOME/"lib/ci/setenv
-
-      ###- name: Setup Terraform
-      ###  uses: hashicorp/setup-terraform@v3
-      ###  with:
-      ###    terraform_wrapper: false
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{env.PYTHON_VERSION}}
 
       - name: setup
         uses: ./tacos-gha/.github/actions/setup

--- a/.github/workflows/tacos_unlock.yml
+++ b/.github/workflows/tacos_unlock.yml
@@ -64,28 +64,8 @@ jobs:
         with:
           python-version: ${{env.PYTHON_VERSION}}
 
-      - name: Setup Terragrunt
-        uses: autero1/action-terragrunt@v1.3.2
-        with:
-          terragrunt_version: ${{env.TERRAGRUNT_VERSION}}
-
-      - name: gcp auth
-        id: auth
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: ${{env.GETSENTRY_SAC_OIDC}}
-          service_account: ${{env.SUDO_GCP_SERVICE_ACCOUNT}}
-
-      - name: set gcloud identity
-        run: |
-          # TODO: upstream feature request on google-github-actions/auth -- this
-          #   should be a default behavior
-          gcloud config get account || : code $?
-          gcloud config set account "$SUDO_GCP_SERVICE_ACCOUNT"
-
-          # also: mask the access token (NOTE: use cat to avoid xtrace'ing the token)
-          # TODO: ditto
-          cat <<< "::add-mask::$(gcloud auth print-access-token)"
+      - name: setup
+        uses: ./tacos-gha/.github/actions/setup
 
       - name: Release Terraform lock
         id: release-terraform-lock

--- a/conftest.py
+++ b/conftest.py
@@ -17,8 +17,7 @@ from lib.types import OSPath
 def user() -> str:
     from lib.constants import USER
 
-    # return USER
-    return "fpacifici"
+    return USER
 
 
 configure_pytest_repr_length = fixture(

--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,8 @@ from lib.types import OSPath
 def user() -> str:
     from lib.constants import USER
 
-    return USER
+    # return USER
+    return "fpacifici"
 
 
 configure_pytest_repr_length = fixture(

--- a/manual_tests/behaviors/force_unlock_on_happy_path.py
+++ b/manual_tests/behaviors/force_unlock_on_happy_path.py
@@ -11,7 +11,7 @@ TEST_NAME = __name__
 
 @pytest.mark.xfail(raises=XFailed)
 def test(pr: tacos_demo.PR) -> None:
-    assert pr.check("Terraform Lock").wait().success
+    assert pr.check("Terraform Plan").wait().success
     # pr.assert_locked()
 
     since = pr.add_label(":taco::unlock")


### PR DESCRIPTION
It seems to me `./tacos-gha/.github/actions/setup` covers what the unlock workflow was doing before to initialize itself.

Verified via the `force_unlock_on_happy_path.py` that this change works. 
https://github.com/getsentry/tacos-gha.demo/pull/989