### PR TITLE
Switches the ready_for_review check to a separate test.

### DIFF
--- a/manual_tests/behaviors/ready_for_review.py
+++ b/manual_tests/behaviors/ready_for_review.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env py.test
+from __future__ import annotations
+
+from lib.sh import sh
+from manual_tests.lib import tacos_demo
+from manual_tests.lib.gh import gh
+from manual_tests.lib.slice import Slices
+
+
+def test(
+    slices: Slices, test_name: str, demo: gh.LocalRepo, tacos_branch: gh.Branch
+) -> None:
+    with tacos_demo.PR.opened_for_slices(
+        slices, test_name, demo, tacos_branch, draft=True
+    ) as pr:
+        sh.banner("Draft PR opened:", pr.url)
+
+        # The terraform_plan check should run automatically when the PR is opened
+        sh.banner("Wait for the terraform_plan check to complete")
+        assert pr.check("Terraform Plan").wait(pr.since).success
+
+        # The slices should not be locked
+        sh.banner("Make sure the slices are not locked")
+        for slice in slices:
+            assert not slice.is_locked()
+
+        sh.banner("Convert Draft PR to non-draft")
+        since = pr.toggle_draft()
+
+        # The terraform_plan check should run automatically when the PR is marked ready
+        sh.banner("Wait for the terraform_plan check to complete")
+        assert pr.check("Terraform Plan").wait(since).success
+
+        # This PR should aquire the lock
+        sh.banner("Make sure the terraform_lock checks ran successfully")
+        pr.slices.assert_locked()

--- a/manual_tests/scenarios/draft_pr.py
+++ b/manual_tests/scenarios/draft_pr.py
@@ -51,24 +51,12 @@ def test(
             pr2.slices.assert_locked()
 
             # Since this is not a draft PR, it should be able to apply the plan
+            since = pr2.approve()
+            assert pr2.is_approved()
             sh.banner("Apply the plan for the second PR")
             since = pr2.add_label(":taco::apply")
             pr2.check("Terraform Apply").wait(since).success
 
-            since = pr2.approve()
-            assert pr2.is_approved()
-
             # Merge the second PR
             sh.banner("Merge the second PR")
             pr2.merge()
-
-        sh.banner("Convert Draft PR to non-draft")
-        since = pr.toggle_draft()
-
-        # The terraform_plan check should run automatically when the PR is marked ready
-        sh.banner("Wait for the terraform_plan check to complete")
-        assert pr.check("Terraform Plan").wait(since).success
-
-        # This PR should aquire the lock
-        sh.banner("Make sure the terraform_lock checks ran successfully")
-        pr.slices.assert_locked()


### PR DESCRIPTION
Workflows for PRs will not run if the PR has conflicts that must be resolved. Trying to test the ready_for_review workflow after merging a conflicting PR would thus fail.