### PR TITLE
pytest cap1fd: capture stdout/stderr combined

### DIFF
--- a/lib/pytest/cap1fd.py
+++ b/lib/pytest/cap1fd.py
@@ -1,0 +1,150 @@
+"""Define a 'cap1fd' pytest fixture which captures stdout/stderr combined."""
+from __future__ import annotations
+
+import contextlib
+from io import FileIO
+from typing import Generator
+
+from _pytest.capture import CaptureBase
+from _pytest.capture import CaptureFixture
+from _pytest.capture import CaptureManager
+from _pytest.capture import NoCapture
+from _pytest.fixtures import SubRequest
+from _pytest.fixtures import fixture
+
+from lib.sh import sh
+
+FD = int
+STDIN: FD = 0
+STDOUT: FD = 1
+STDERR: FD = 2
+
+
+class FDCapture(CaptureBase[str]):
+    def __init__(  # pyright: ignore[reportMissingSuperCall]  # TODO: bugreport
+        self, targetfd: FD, **_: object
+    ):
+        from os import dup
+        from tempfile import TemporaryFile
+
+        self.targetfd = targetfd
+
+        self.tmpfile: FileIO = TemporaryFile(buffering=0)
+        self.targetfd_save: FD = dup(targetfd)
+        self.exitstack: contextlib.ExitStack = contextlib.ExitStack()
+
+    def start(self) -> None:
+        self.resume()
+
+    def done(self) -> None:
+        self.suspend()
+        self.tmpfile.close()
+
+    def suspend(self) -> None:
+        self.exitstack.__exit__(None, None, None)
+
+    def resume(self) -> None:
+        self.exitstack.enter_context(
+            sh.redirect(self.targetfd, self.tmpfile.fileno())
+        )
+
+    def writeorg(self, data: str) -> None:
+        """Write to original file descriptor."""
+        import os
+
+        os.write(self.targetfd_save, data.encode())
+
+    def snap(self) -> str:
+        self.tmpfile.seek(0)
+        result = self.tmpfile.read()
+        self.tmpfile.truncate(0)
+        return result.decode()
+
+
+class CombinedCapture(FDCapture):
+    def __init__(self, targetfd: FD, *other_fds: FD):
+        super().__init__(targetfd)
+        self.other_fds = other_fds
+
+    def resume(self) -> None:
+        super().resume()
+        for other_fd in self.other_fds:
+            self.exitstack.enter_context(sh.redirect(other_fd, self.targetfd))
+
+
+class NoopCapture(FDCapture):
+    def resume(self) -> None:
+        pass
+
+
+class CombinedFDCapture(CaptureBase[str]):
+    EMPTY_BUFFER: str = ""
+    capture: CaptureBase[str]
+
+    def __init__(  # pyright: ignore[reportMissingSuperCall]
+        self, targetfd: FD
+    ):
+        if targetfd == 1:
+            self.capture = CombinedCapture(targetfd, STDERR)
+        elif targetfd == 2:
+            self.capture = NoCapture(targetfd)
+        else:
+            raise ValueError(targetfd)
+
+    def start(self) -> None:
+        self.capture.start()
+
+    def done(self) -> None:
+        self.capture.done()
+
+    def suspend(self) -> None:
+        self.capture.suspend()
+
+    def resume(self) -> None:
+        self.capture.resume()
+
+    def writeorg(self, data: str) -> None:
+        self.capture.writeorg(data)
+
+    def snap(self) -> str:
+        return self.capture.snap()
+
+
+@fixture
+def cap1fd(request: SubRequest) -> Generator[CaptureFixture[str], None, None]:
+    r"""Enable text capturing of writes to stdout and stderr, combined.
+
+    This enables accurate temporal interleaving of writes, at the cost of
+    losing the ability to distinguish between out and err. This is often
+    beneficical because:
+        1. it's how users and logs will see the output, by default
+        3. the temporal relationship between output and errors is highly
+            relevant to users and to tests
+        3. under test, combined longs are easier to understand and debug
+
+    ``cap1fd.readouterr()`` will return combined output as `out` and
+    empty-string as `err`.
+
+    Returns an instance of :class:`CaptureFixture[str]`.
+
+    Example:
+
+    .. code-block:: python
+
+        def test_system_echo(cap1fd):
+            os.system('echo "hello"; echo ERROR >&2')
+            captured = cap1fd.readouterr()
+            assert captured.out == "hello\nERROR\n"
+    """
+    capman = request.config.pluginmanager.getplugin("capturemanager")
+    assert isinstance(capman, CaptureManager), capman
+    capture_fixture = CaptureFixture(
+        CombinedFDCapture, request, _ispytest=True
+    )
+    try:
+        capman.set_fixture(capture_fixture)
+        capture_fixture._start()  # pyright: ignore[reportPrivateUsage]
+        yield capture_fixture
+    finally:
+        capture_fixture.close()
+        capman.unset_fixture()

--- a/lib/pytest/cap1fd_plugin.py
+++ b/lib/pytest/cap1fd_plugin.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+from typing import Generator
+
+from _pytest.capture import CaptureManager
+from _pytest.capture import MultiCapture
+from _pytest.config import hookimpl
+
+from .cap1fd import CombinedFDCapture
+
+if TYPE_CHECKING:
+    from _pytest.capture import (
+        _CaptureMethod,  # pyright: ignore[reportPrivateUsage]; isort:skip
+    )
+
+
+def _get_multicapture(method: _CaptureMethod) -> MultiCapture[str]:
+    if method == "no":
+        return MultiCapture(in_=None, out=None, err=None)
+    else:
+        return MultiCapture(
+            in_=None, out=CombinedFDCapture(1), err=CombinedFDCapture(2)
+        )
+
+
+class MyCaptureManager(CaptureManager):
+    def start_global_capturing(self) -> None:
+        assert self._global_capturing is None
+        self._global_capturing = _get_multicapture(self._method)
+        self._global_capturing.start_capturing()
+
+
+UNSET = object()
+Vars = dict[str, object]
+
+
+@contextlib.contextmanager
+def patched(obj: object, **attrs: object) -> Generator[Vars, None, None]:
+    oldattrs: dict[str, object] = {}
+    for attr, value in attrs.items():
+        oldattrs[attr] = getattr(obj, attr, UNSET)
+        setattr(obj, attr, value)
+
+    try:
+        yield oldattrs
+
+    finally:
+        for attr, value in oldattrs.items():
+            if value is UNSET:
+                delattr(obj, attr)
+            else:
+                setattr(obj, attr, value)
+
+
+@hookimpl(hookwrapper=True)
+def pytest_load_initial_conftests() -> Generator[None, None, None]:
+    import _pytest.capture
+
+    with patched(_pytest.capture, CaptureManager=MyCaptureManager):
+        yield

--- a/lib/pytest/cap1fd_test.py
+++ b/lib/pytest/cap1fd_test.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+from _pytest.capture import CaptureFixture
+
+from lib.sh import sh
+from lib.types import Generator
+
+# fixture
+from .cap1fd import cap1fd as cap1fd
+
+
+def capfd(
+    logging: None, capfd: pytest.CaptureFixture[str]
+) -> Generator[pytest.CaptureFixture[str]]:
+    del logging
+    yield capfd
+
+
+class DescribeCaptureCombined:
+    def it_combines_stderr(self, cap1fd: CaptureFixture[str]) -> None:
+        sh.run(("sh", "-c", "echo stdout >&1; echo stderr >&2"))
+
+        std = cap1fd.readouterr()
+        print("STDOUT:\n", std.out)
+        print("STDERR:\n", std.err)
+        assert std.err == ""
+        assert (
+            std.out
+            == """\
++ \x1b[36;1m$\x1b[m sh -c 'echo stdout >&1; echo stderr >&2'
+stdout
+stderr
+"""
+        )

--- a/lib/sh/cd.py
+++ b/lib/sh/cd.py
@@ -12,8 +12,7 @@ from lib.types import OSPath
 from lib.types import Path
 
 from .core import run
-from .io import banner as banner
-from .io import info as info
+from .io import debug2
 from .io import xtrace
 from .json import json
 
@@ -55,5 +54,5 @@ def cd(
     finally:  # undo the cd and log it
         chdir(oldpwd)
         env["PWD"] = str(oldpwd)
-        xtrace(("popd",))
-        info(oldpwd, "<-", newpwd)
+        xtrace(("popd",), level=2)
+        debug2(oldpwd, "<-", newpwd)

--- a/lib/sh/constant.py
+++ b/lib/sh/constant.py
@@ -1,3 +1,8 @@
 from __future__ import annotations
 
+from .types import FD
+
 US_ASCII = "US-ASCII"  # the least-ambiguous encoding
+STDIN: FD = 0
+STDOUT: FD = 1
+STDERR: FD = 2

--- a/lib/sh/core.py
+++ b/lib/sh/core.py
@@ -101,11 +101,11 @@ def success(cmd: Command, returncode: int = 0) -> bool:
     return _returncode(cmd) == returncode
 
 
-def _stringify(o: object) -> bytes:
+def _stringify(o: object) -> str:
     if isinstance(o, bytes):
-        return o
+        return o.decode("US-ASCII")  # other bytes are ambiguous
     else:
-        return str(o).encode("US-ASCII")  # other bytes are ambiguous
+        return str(o)
 
 
 def _popen(

--- a/lib/sh/io.py
+++ b/lib/sh/io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 from os import getenv
 from typing import ContextManager
+from typing import Iterable
 
 from lib import ansi
 
@@ -60,17 +61,33 @@ def quote(cmd: Command) -> str:
     return " ".join(shlex.quote(_stringify(arg)) for arg in cmd)
 
 
-def xtrace(cmd: Command) -> None:
+def xtrace(cmd: Command, *, level: int = 1) -> None:
     """Simulate bash's xtrace: show a command with copy-pasteable escaping.
 
-    Output is suppressed when `sh.DEBUG` is False.
+    Output is suppressed when `sh.DEBUG` (default 1) is less than `level`.
     """
-    debug("".join((PS4, quote(cmd))))
+    debug("".join((PS4, quote(cmd))), level=level)
 
 
-def debug(*msg: object) -> None:
-    if DEBUG:
+def debugN(msg: Iterable[object], level: int) -> None:
+    if DEBUG >= level:
         info(*msg)
+
+
+def debug(*msg: object, level: int = 1) -> None:
+    debugN(msg, level)
+
+
+def debug1(*msg: object) -> None:
+    debugN(msg, 1)
+
+
+def debug2(*msg: object) -> None:
+    debugN(msg, 2)
+
+
+def debug3(*msg: object) -> None:
+    debugN(msg, 3)
 
 
 @contextlib.contextmanager

--- a/lib/sh/sh.py
+++ b/lib/sh/sh.py
@@ -4,16 +4,8 @@ from __future__ import annotations
 from subprocess import CalledProcessError as CalledProcessError
 from subprocess import TimeoutExpired as TimeoutExpired
 
-from . import io as io
 from .cd import cd as cd
-from .core import *
-from .io import banner as banner
-from .io import debug as debug
-from .io import info as info
-from .io import loud as loud
-from .io import quiet as quiet
-from .io import quote as quote
-from .io import uniq as uniq
-from .io import xtrace as xtrace
+from .core import *  # run, lines, stdout, success, ...
+from .io import *  # info, debug, xtrace, redirect, ...
 from .json import jq as jq
 from .json import json as json

--- a/lib/sh/types.py
+++ b/lib/sh/types.py
@@ -3,3 +3,4 @@ from __future__ import annotations
 from lib.types import Generator as Generator
 
 Command = tuple[object, ...]
+FD = int  # File Descriptor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ skip_covered = false
 minversion = "6.0"
 markers = []
 xfail_strict = true
-addopts = "--durations-min=10 -vv --doctest-modules --capture=no --last-failed"
+addopts = "-p lib.pytest.cap1fd_plugin --durations-min=10 -vv --doctest-modules --capture=no --last-failed"
 testpaths = ["."]
 norecursedirs = [
     "**/__pycache__",


### PR DESCRIPTION
Enable text capturing of writes to stdout and stderr, combined.

This enables accurate temporal interleaving of writes, at the cost of
losing the ability to distinguish between out and err. This is often
beneficical because:

1. it's how users and logs will see the output, by default
3. the temporal relationship between output and errors is highly
    relevant to users and to tests
3. under test, combined longs are easier to understand and debug
