### PR TITLE
Bumping gha deps to use node20

### DIFF
--- a/.github/actions/list-slices/action.yml
+++ b/.github/actions/list-slices/action.yml
@@ -17,7 +17,7 @@ runs:
     - uses: ./tacos-gha/.github/actions/just-the-basics
 
     - id: files
-      uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd
+      uses: dorny/paths-filter@3.0.1
       with:
         filters: "all: ['**']"
         list-files: json

--- a/.github/actions/list-slices/action.yml
+++ b/.github/actions/list-slices/action.yml
@@ -17,7 +17,7 @@ runs:
     - uses: ./tacos-gha/.github/actions/just-the-basics
 
     - id: files
-      uses: getsentry/paths-filter@v2.11.1
+      uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd
       with:
         filters: "all: ['**']"
         list-files: json

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -64,7 +64,7 @@ runs:
 
     - name: gcp auth
       id: auth
-      uses: google-github-actions/auth@v1
+      uses: google-github-actions/auth@v2.1.1
       with:
         workload_identity_provider: ${{env.GETSENTRY_SAC_OIDC}}
         service_account: ${{env.SUDO_GCP_SERVICE_ACCOUNT}}


### PR DESCRIPTION
Resolves some of the deprecation warnings. There are a few actions that haven't release a node20 compatible version yet such as https://github.com/autero1/action-terragrunt, https://github.com/thollander/actions-comment-pull-request, and https://github.com/bukzor/direnv-install.