### PR TITLE
fix: tacos sometimes confused about which `lib` to import

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -25,3 +25,6 @@ export TERRAGRUNT_INCLUDE_MODULE_PREFIX=${TERRAGRUNT_INCLUDE_MODULE_PREFIX:-true
 export TF_CLI_ARGS_plan="-lock=false -out=plan"
 export TERRAGRUNT_NO_AUTO_INIT=false
 export TERRAGRUNT_NO_AUTO_RETRY=false
+
+# tacos confused about which lib to import
+export PYTHONSAFEPATH=1

--- a/.github/actions/matrix-fan-out/square.py
+++ b/.github/actions/matrix-fan-out/square.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3.12 -P
+#!/usr/bin/env python3
 # a silly script to print the "square" of a number:
 #
 # $ square.py 4

--- a/.github/actions/matrix-fan-out/square.py
+++ b/.github/actions/matrix-fan-out/square.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -P
 # a silly script to print the "square" of a number:
 #
 # $ square.py 4

--- a/.github/actions/matrix-fan-out/square.py
+++ b/.github/actions/matrix-fan-out/square.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -P
+#!/usr/bin/env -S python3.12 -P
 # a silly script to print the "square" of a number:
 #
 # $ square.py 4

--- a/lib/ci/list-slices
+++ b/lib/ci/list-slices
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 jq '.[]' --raw-output |
-  python3 -P -m lib.tacos.dependent_slices |
+  python3.12 -P -m lib.tacos.dependent_slices |
   # transform newline-delimited list into json:
   jq -R |
   jq -cs |

--- a/lib/ci/list-slices
+++ b/lib/ci/list-slices
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 jq '.[]' --raw-output |
-  python3 -m lib.tacos.dependent_slices |
+  python3 -P -m lib.tacos.dependent_slices |
   # transform newline-delimited list into json:
   jq -R |
   jq -cs |

--- a/lib/ci/release-lock
+++ b/lib/ci/release-lock
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -P
+#!/usr/bin/env -S python3.12 -P
 """
 This implements the Tacos Unlock GHA job.
 """

--- a/lib/ci/release-lock
+++ b/lib/ci/release-lock
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -P
 """
 This implements the Tacos Unlock GHA job.
 """

--- a/lib/ci/tacos-apply-summary
+++ b/lib/ci/tacos-apply-summary
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-python3.12 -m lib.ci.tacos_apply_summary
+python3.12 -P -m lib.ci.tacos_apply_summary

--- a/lib/ci/tacos-plan-summary
+++ b/lib/ci/tacos-plan-summary
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-python3.12 -m lib.ci.tacos_plan_summary
+python3.12 -P -m lib.ci.tacos_plan_summary

--- a/lib/ci/tacos-unlock-summary
+++ b/lib/ci/tacos-unlock-summary
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-python3.12 -m lib.ci.tacos_unlock_summary
+python3.12 -P -m lib.ci.tacos_unlock_summary

--- a/lib/ci/tacos_apply_summary.py
+++ b/lib/ci/tacos_apply_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -P
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from typing import Collection

--- a/lib/ci/tacos_apply_summary.py
+++ b/lib/ci/tacos_apply_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -P
 from __future__ import annotations
 
 from typing import Collection

--- a/lib/ci/tacos_plan_summary.py
+++ b/lib/ci/tacos_plan_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -P
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from typing import Collection

--- a/lib/ci/tacos_plan_summary.py
+++ b/lib/ci/tacos_plan_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -P
 from __future__ import annotations
 
 from typing import Collection

--- a/lib/ci/tacos_unlock_summary.py
+++ b/lib/ci/tacos_unlock_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -P
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from typing import Collection

--- a/lib/ci/tacos_unlock_summary.py
+++ b/lib/ci/tacos_unlock_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -P
 from __future__ import annotations
 
 from typing import Collection

--- a/lib/make/coverage-server
+++ b/lib/make/coverage-server
@@ -9,7 +9,7 @@ fi
 
 set -x
 
-python3 \
+python3 -P\
   -m http.server \
   --directory ./coverage-html \
   --bind 127.0.0.1 \

--- a/lib/make/coverage-server
+++ b/lib/make/coverage-server
@@ -9,7 +9,7 @@ fi
 
 set -x
 
-python3 -P\
+python3.12 -P \
   -m http.server \
   --directory ./coverage-html \
   --bind 127.0.0.1 \

--- a/lib/tacos/conflict_detection.py
+++ b/lib/tacos/conflict_detection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.12
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from lib import json

--- a/lib/tacos/dependent_slices.py
+++ b/lib/tacos/dependent_slices.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.12
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 import typing

--- a/lib/tacos/install_labels.py
+++ b/lib/tacos/install_labels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.12
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/lib/tacos/path_filter.py
+++ b/lib/tacos/path_filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.12
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/lib/tacos/slices
+++ b/lib/tacos/slices
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 # FIXME: we need pip packaging
-python3.12 -m lib.tacos.slices "$@" |
-  python3.12 -m lib.tacos.path_filter \
+python3.12 -P -m lib.tacos.slices "$@" |
+  python3.12 -P -m lib.tacos.path_filter \
 ;

--- a/lib/tacos/slices.py
+++ b/lib/tacos/slices.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.12
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from .dependent_slices import TFCategorized

--- a/lib/tf_lock/lib/acquire.py
+++ b/lib/tf_lock/lib/acquire.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.12
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 import asyncio

--- a/lib/tf_lock/release.py
+++ b/lib/tf_lock/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.12
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/lib/tf_lock/tf-lock-acquire
+++ b/lib/tf_lock/tf-lock-acquire
@@ -4,4 +4,4 @@ HERE="$(dirname "$(readlink -f "$0")")"
 . "$HERE/"lib/env.sh
 
 # FIXME: we need pip packaging
-python3.12 -m lib.tf_lock.tf_lock_acquire "$@"
+python3.12 -P -m lib.tf_lock.tf_lock_acquire "$@"

--- a/lib/tf_lock/tf-lock-release
+++ b/lib/tf_lock/tf-lock-release
@@ -4,4 +4,4 @@ HERE="$(dirname "$(readlink -f "$0")")"
 . "$HERE/"lib/env.sh
 
 # FIXME: we need pip packaging
-python3.12 -m lib.tf_lock.release "$@"
+python3.12 -P -m lib.tf_lock.release "$@"

--- a/lib/tf_lock/tf_lock_acquire.py
+++ b/lib/tf_lock/tf_lock_acquire.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -P
 """Acquire the terraform state lock and print its ID (an integer)"""
 
 from __future__ import annotations

--- a/lib/tf_lock/tf_lock_acquire.py
+++ b/lib/tf_lock/tf_lock_acquire.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -P
+#!/usr/bin/env -S python3.12 -P
 """Acquire the terraform state lock and print its ID (an integer)"""
 
 from __future__ import annotations

--- a/lib/unix/nearest-config-file
+++ b/lib/unix/nearest-config-file
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -P
+#!/usr/bin/env -S python3.12 -P
 from __future__ import annotations
 
 from pathlib import Path

--- a/lib/unix/nearest-config-file
+++ b/lib/unix/nearest-config-file
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -P
 from __future__ import annotations
 
 from pathlib import Path


### PR DESCRIPTION
 the fix amounts to ensuring we use `-P` and/or `$PYTHONSAFEPATH` everywhere:

```
$ man python3.12
...
       -P     Don't automatically prepend a potentially unsafe path to sys.path such as the current directory, the script's directory or an empty string. See also
              the PYTHONSAFEPATH environment variable.
```

this prevents the system from getting confused about where to find `import lib` even when `$PWD/lib/__init__.py` exists