### PR TITLE
Making datadog keys available to tacos

### DIFF
--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -128,7 +128,7 @@ jobs:
         id: main
         run: |
           "$TACOS_GHA_HOME/"lib/ci/tacos-plan
-        if: {{ github.repository }} == 'ops'
+        if: {{ github.repository }} == 'getsentry/ops'
         env:
           datadog_api_key: ${{ secrets.TF_VAR_DATADOG_API_KEY }}
           datadog_app_key: ${{ secrets.TF_VAR_DATADOG_APP_KEY }}

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -128,6 +128,7 @@ jobs:
         id: main
         run: |
           "$TACOS_GHA_HOME/"lib/ci/tacos-plan
+        if: {{ github.repository }} == 'ops'
         env:
           datadog_api_key: ${{ secrets.TF_VAR_DATADOG_API_KEY }}
           datadog_app_key: ${{ secrets.TF_VAR_DATADOG_APP_KEY }}

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -128,6 +128,9 @@ jobs:
         id: main
         run: |
           "$TACOS_GHA_HOME/"lib/ci/tacos-plan
+        env:
+          datadog_api_key: ${{ secrets.TF_VAR_DATADOG_API_KEY }}
+          datadog_app_key: ${{ secrets.TF_VAR_DATADOG_APP_KEY }}
 
       - name: Save matrix result
         # we need to show any errors to end-users


### PR DESCRIPTION
@jeffrey-sentry added `TF_VAR_DATADOG_API_KEY` and `TF_VAR_DATADOG_APP_KEY` in Github Actions for [ops](https://github.com/getsentry/ops/settings).

![gha](https://github.com/getsentry/ops/assets/10428678/557b42e3-12dc-4af9-9029-228fe84929ef)

This PR updates tf plan script to read the keys to fix [this](https://github.com/getsentry/ops/actions/runs/9355509014/job/25750833444#step:5:91) tacos issue.
