### PR TITLE
Support passing provider custom secrets to TACOs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -94,7 +94,8 @@ runs:
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key"
-          gha-set-env "TF_VAR_$key" <<< "::add-mask::$value"
+          echo "::add-mask::$value"
+          gha-set-env "TF_VAR_$key" <<< "$value"
         done
 
     # this should really be default behavior:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -93,8 +93,8 @@ runs:
         echo -e "${{ inputs.tf-provider-secrets }}" | \
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
-          echo "Setting: $key, Value: ::add-mask::$value"
-          gha-set-env "TF_VAR_$key" <<< "$value"
+          echo "Setting: $key"
+          gha-set-env "TF_VAR_$key" <<< "::add-mask::$value"
         done
 
     # this should really be default behavior:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -90,8 +90,8 @@ runs:
       run: |
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
-
-        echo -e ${{ inputs.tf-provider-secrets }} | \
+        echo "var ${{ inputs.tf-provider-secrets }}"
+        echo ${{ inputs.tf-provider-secrets }} | \
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key, Value: ::add-mask::$value"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -91,7 +91,9 @@ runs:
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
         echo -e "var ${{ inputs.tf-provider-secrets }}"
-        echo -e ${{ inputs.tf-provider-secrets }} | jq -r 'to_entries[] | "\(.key)=\(.value)"' | while IFS== read -r key value; do
+        echo -e "${{ inputs.tf-provider-secrets }}" | \
+        jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
+        while IFS== read -r key value; do
           echo "Setting: $key, Value: ::add-mask::$value"
           gha-set-env "TF_VAR_$key" <<< "$value"
         done

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -91,9 +91,7 @@ runs:
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
         echo -e "var ${{ inputs.tf-provider-secrets }}"
-        echo -e ${{ inputs.tf-provider-secrets }} | \
-        jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
-        while IFS== read -r key value; do
+        echo -e ${{ inputs.tf-provider-secrets }} | jq -r 'to_entries[] | "\(.key)=\(.value)"' | while IFS== read -r key value; do
           echo "Setting: $key, Value: ::add-mask::$value"
           gha-set-env "TF_VAR_$key" <<< "$value"
         done

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -91,7 +91,7 @@ runs:
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
 
-        echo ${{ inputs.tf-provider-secrets }} | \
+        echo -e ${{ inputs.tf-provider-secrets }} | \
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key, Value: ::add-mask::$value"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -90,7 +90,7 @@ runs:
       run: |
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
-        echo -e "${{ secrets.tf-provider-secrets }}" | \
+        echo -e "${{ inputs.tf-provider-secrets }}" | \
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key, Value: ::add-mask::$value"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,6 @@ inputs:
   shell:
     description: "private -- do not use"
     default: env ./tacos-gha/lib/ci/default-shell {0}
-secrets:  
   tf-provider-secrets:
     description: Json map containing the secrets to be set as env vars for TF.
     required: false
@@ -92,7 +91,7 @@ runs:
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
 
-        echo ${{ secrets.tf-provider-secrets }} | \
+        echo ${{ inputs.tf-provider-secrets }} | \
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key, Value: ::add-mask::$value"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -90,8 +90,8 @@ runs:
       run: |
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
-        echo "var ${{ inputs.tf-provider-secrets }}"
-        echo ${{ inputs.tf-provider-secrets }} | \
+        echo -e "var ${{ inputs.tf-provider-secrets }}"
+        echo -e ${{ inputs.tf-provider-secrets }} | \
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key, Value: ::add-mask::$value"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -94,7 +94,7 @@ runs:
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key"
-          echo "::add-mask::$value"
+          cat <<< "::add-mask::$value"
           gha-set-env "TF_VAR_$key" <<< "$value"
         done
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -90,7 +90,7 @@ runs:
       run: |
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
-        echo -e "${{ inputs.tf-provider-secrets }}" | \
+        cat <<< "${{ inputs.tf-provider-secrets }}" | \
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,6 +12,7 @@ inputs:
   shell:
     description: "private -- do not use"
     default: env ./tacos-gha/lib/ci/default-shell {0}
+secrets:  
   tf-provider-secrets:
     description: Json map containing the secrets to be set as env vars for TF.
     required: false

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -90,8 +90,7 @@ runs:
       run: |
         # The provider secrets are passed to terraform as variable, thus
         # setting a TF_VAR environment variable each.
-        echo -e "var ${{ inputs.tf-provider-secrets }}"
-        echo -e "${{ inputs.tf-provider-secrets }}" | \
+        echo -e "${{ secrets.tf-provider-secrets }}" | \
         jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
         while IFS== read -r key value; do
           echo "Setting: $key, Value: ::add-mask::$value"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,6 +12,9 @@ inputs:
   shell:
     description: "private -- do not use"
     default: env ./tacos-gha/lib/ci/default-shell {0}
+  tf-provider-secrets:
+    description: Json map containing the secrets to be set as env vars for TF.
+    required: false
 
 runs:
   using: composite
@@ -81,6 +84,19 @@ runs:
         # TODO: upstream feature request on google-github-actions/auth -- this
         #   should be a default behavior
         cat <<< "::add-mask::$(gcloud auth print-access-token)"
+
+    - name: pass provider secrets to terraform
+      shell: ${{inputs.shell}}
+      run: |
+        # The provider secrets are passed to terraform as variable, thus
+        # setting a TF_VAR environment variable each.
+
+        echo ${{ secrets.tf-provider-secrets }} | \
+        jq -r 'to_entries[] | "\(.key)=\(.value)"' | \
+        while IFS== read -r key value; do
+          echo "Setting: $key, Value: ::add-mask::$value"
+          gha-set-env "TF_VAR_$key" <<< "$value"
+        done
 
     # this should really be default behavior:
     - shell: ${{inputs.shell}}

--- a/.github/workflows/tacos_apply.yml
+++ b/.github/workflows/tacos_apply.yml
@@ -17,6 +17,14 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      tf-provider-secrets:
+        description: |
+          Json map containing the secrets TF providers need to operate.
+          Each entry of the map represents a secret. 
+          Each secret (example: `PAGERDUTY_TOKEN: zxczxcz...`) is unpacked
+          and set as TF_VAR environment variable: `TF_VAR_PAGERDUTY_TOKEN`
+          in this case.
+        required: false
 
 defaults:
   run:
@@ -94,6 +102,7 @@ jobs:
         uses: ./tacos-gha/.github/actions/setup
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
+          tf-provider-secrets: ${{ secrets.tf-provider-secrets }}
 
       # TODO: fetch and apply the tfplan artifact from plan workflow
       # so that apply matches the plan reviewed by construction

--- a/.github/workflows/tacos_detect_drift.yml
+++ b/.github/workflows/tacos_detect_drift.yml
@@ -17,6 +17,14 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      tf-provider-secrets:
+        description: |
+          Json map containing the secrets TF providers need to operate.
+          Each entry of the map represents a secret. 
+          Each secret (example: `PAGERDUTY_TOKEN: zxczxcz...`) is unpacked
+          and set as TF_VAR environment variable: `TF_VAR_PAGERDUTY_TOKEN`
+          in this case.
+        required: false
 
 defaults:
   run:
@@ -85,6 +93,7 @@ jobs:
         uses: ./tacos-gha/.github/actions/setup
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
+          tf-provider-secrets: ${{ secrets.tf-provider-secrets }}
 
       - name: Detect drift
         run: |

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -20,6 +20,14 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      tf-provider-secrets:
+        description: |
+          Json map containing the secrets TF providers need to operate.
+          Each entry of the map represents a secret. 
+          Each secret (example: `PAGERDUTY_TOKEN: zxczxcz...`) is unpacked
+          and set as TF_VAR environment variable: `TF_VAR_PAGERDUTY_TOKEN`
+          in this case.
+        required: false
 
 defaults:
   run:

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -105,6 +105,7 @@ jobs:
         uses: ./tacos-gha/.github/actions/setup
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
+          tf-provider-secrets: ${{ secrets.tf-provider-secrets }}
           # We explicitly list the low-concern actions, during which users will
           # recieve a higher level of access -- the identity of the original PR
           # author. All other actions will receive lower access -- the identity

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -106,7 +106,7 @@ jobs:
         uses: ./tacos-gha/.github/actions/setup
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-          tf-provider-secrets: ${{ inputs.tf-provider-secrets }}
+          tf-provider-secrets: ${{ secrets.tf-provider-secrets }}
           # We explicitly list the low-concern actions, during which users will
           # recieve a higher level of access -- the identity of the original PR
           # author. All other actions will receive lower access -- the identity

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -16,11 +16,8 @@ on:
       debug:
         type: string
         default: 0
-    secrets:
-      ssh-private-key:
-        description: "Private SSH key to use for git clone"
-        required: false
       tf-provider-secrets:
+        type: string
         description: |
           Json map containing the secrets TF providers need to operate.
           Each entry of the map represents a secret. 
@@ -28,6 +25,11 @@ on:
           and set as TF_VAR environment variable: `TF_VAR_PAGERDUTY_TOKEN`
           in this case.
         required: false
+    secrets:
+      ssh-private-key:
+        description: "Private SSH key to use for git clone"
+        required: false
+      
 
 defaults:
   run:
@@ -105,7 +107,7 @@ jobs:
         uses: ./tacos-gha/.github/actions/setup
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
-          tf-provider-secrets: ${{ secrets.tf-provider-secrets }}
+          tf-provider-secrets: ${{ inputs.tf-provider-secrets }}
           # We explicitly list the low-concern actions, during which users will
           # recieve a higher level of access -- the identity of the original PR
           # author. All other actions will receive lower access -- the identity

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -16,18 +16,17 @@ on:
       debug:
         type: string
         default: 0
+    secrets:
+      ssh-private-key:
+        description: "Private SSH key to use for git clone"
+        required: false
       tf-provider-secrets:
-        type: string
         description: |
           Json map containing the secrets TF providers need to operate.
           Each entry of the map represents a secret. 
           Each secret (example: `PAGERDUTY_TOKEN: zxczxcz...`) is unpacked
           and set as TF_VAR environment variable: `TF_VAR_PAGERDUTY_TOKEN`
           in this case.
-        required: false
-    secrets:
-      ssh-private-key:
-        description: "Private SSH key to use for git clone"
         required: false
       
 


### PR DESCRIPTION
Soem Terraform provider need secrets for authentication. For example the datadog one
 and the pagerduty one.

TACOs does not provide, as of today, a way to provide those secrets as they are specific
to the slices and providers the client is using. 

This PR adds a new `secret` to all the acitons where the secret is needed: plan, apply,
drift detection. This secret is provided as a json object where each key represents a
secret. 

The `setup` action unpacks it and sets an environment variable for terraform per secret.
It also ensures all the secret values are masked.

Secrets are going to be provided to terraform as variable by setting `TF_VAR_` environment
variables. This happens once per secret.

See it working on this PR https://github.com/getsentry/ops/actions/runs/9521154268.
I checked that the secret is never in visible in the log.

