### PR TITLE
add skipped status

### DIFF
--- a/spec/lib/gh/check_run.py
+++ b/spec/lib/gh/check_run.py
@@ -99,9 +99,14 @@ class CheckRun:
 
         try:
             result.append(
-                ("NEUTRAL", "SUCCESS", "CANCELLED", "", "FAILURE").index(
-                    self.conclusion
-                )
+                (
+                    "NEUTRAL",
+                    "SKIPPED",
+                    "SUCCESS",
+                    "CANCELLED",
+                    "",
+                    "FAILURE",
+                ).index(self.conclusion)
             )
         except ValueError as error:
             raise AssertionError(


### PR DESCRIPTION
tests fail as SKIPPED is a valid check status which is sometimes returned from the API but not handled here