### PR TITLE
add required check workflow

### DIFF
--- a/.github/workflows/required_check.yml
+++ b/.github/workflows/required_check.yml
@@ -1,7 +1,18 @@
 name: Required check
 
 on:
-  pull_request:
+  workflow_call:
+    inputs:
+      tacos_gha_repo:
+        type: string
+        default: getsentry/tacos-gha
+      tacos_gha_ref:
+        type: string
+        default: refs/heads/stable
+    secrets:
+      ssh-private-key:
+        description: "Private SSH key to use for git clone"
+        required: false
 
 jobs:
   required_check:

--- a/.github/workflows/required_check.yml
+++ b/.github/workflows/required_check.yml
@@ -1,0 +1,17 @@
+name: Required check
+
+on:
+  pull_request:
+
+jobs:
+  required_check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout IAC
+        uses: actions/checkout@v4
+      - name: Perform check
+        run: |
+          if [ -e required_check.fail ]; then exit 1; fi


### PR DESCRIPTION
this is the first part of a change to make tacos apply depend on required checks passing

it adds a new `required-check` workflow. once this is merged, it also needs to be marked as "required" in github.

this is needed in order to be able to write a test case that will fail to perform tacos apply when this check fails.