### PR TITLE
Adds permissions for viewing checks/actions (#242) (#257)

### DIFF
--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -81,6 +81,8 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      checks: read
+      actions: read
 
     env:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}

--- a/.github/workflows/tacos_unlock.yml
+++ b/.github/workflows/tacos_unlock.yml
@@ -76,6 +76,8 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
+      checks: read
+      actions: read
 
     env:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}


### PR DESCRIPTION
See #242 

This needed to be done for plan/unlock too, for the headers to get their urls linked.

Brings changes from https://github.com/getsentry/tacos-gha/pull/257

Testing in https://github.com/getsentry/ops/pull/13162#issuecomment-2518494986

![image](https://github.com/user-attachments/assets/5e783a24-562e-4f67-ac12-0988c5b4d3b8)
