### PR TITLE
fix: gcloud-auth-export-access-token under fish shell

### DIFF
--- a/lib/gcloud/gcloud-auth-export-access-token
+++ b/lib/gcloud/gcloud-auth-export-access-token
@@ -84,21 +84,13 @@ else
   error "FAILED: don't know how to authenticate as '$target_identity'"
 fi
 
-# NOTE: CLOUDSDK_CORE_ACCOUNT is necessary to get the right user during 
+# NOTE: CLOUDSDK_CORE_ACCOUNT is necessary to get the right user during
 # `gcloud compute ssh`
-if [[ "$SHELL" =~ (^|/)fish$ ]]; then
-  cat <<EOF
-set -x CLOUDSDK_CORE_ACCOUNT "$target_identity"
-set -x GOOGLE_OAUTH_ACCESS_TOKEN '$token'
-set -x CLOUDSDK_AUTH_ACCESS_TOKEN "\$GOOGLE_OAUTH_ACCESS_TOKEN"
-EOF
-else
-  cat <<EOF
+cat <<EOF
 export CLOUDSDK_CORE_ACCOUNT="$target_identity"
 export GOOGLE_OAUTH_ACCESS_TOKEN='$token'
 export CLOUDSDK_AUTH_ACCESS_TOKEN="\$GOOGLE_OAUTH_ACCESS_TOKEN"
 EOF
-fi
 
 info "You are authenticated for the next hour as: $target_identity"
 


### PR DESCRIPTION
was provisioning a terraform sandbox and ran into an unbound var error for  CLOUDSDK_AUTH_ACCESS_TOKEN

this is because gcloud-auth-export-access-token outputs correct fish syntax which is then passed to an eval in sudo-gcp, however sudo-gcp is always running under `/bin/bash`. So we should just always give it correct bash instead.