### PR TITLE
Allow anyone to use the :taco::apply label, not just the PR owner.

### DIFF
--- a/.github/workflows/tacos_apply.yml
+++ b/.github/workflows/tacos_apply.yml
@@ -96,6 +96,23 @@ jobs:
         uses: ./tacos-gha/.github/actions/setup
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
+          # We explicitly list the low-concern actions, during which users will
+          # recieve a higher level of access -- the identity of the original PR
+          # author. All other actions will receive lower access -- the identity
+          # of the person pushing the "Re-run" button.
+          #
+          # see doc/permissions.md
+          user: |-
+            ${{
+              true
+              && github.event_name == 'pull_request'
+              && github.event.action == 'labeled'
+              && github.event.label.name == ':taco::apply'
+
+              && github.event.pull_request.user.login
+
+              || github.triggering_actor
+            }}
 
       # TODO: fetch and apply the tfplan artifact from plan workflow
       # so that apply matches the plan reviewed by construction

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -2,13 +2,14 @@
 
 - only the original pr author allowed, so identity set to user trying the action
   (USER=github.triggering_actor)
-  - apply
-    - the original author is the responsible party for all prod changes
   - taco::unlock
     - to steal the lock, you must close or draft the PR
       - could then reopen PR of the same branch, to transfer ownership
 - anyone that has the relevant github permission, so identity set to original
   author (USER=github.event.pull_request.user.login)
+  - apply
+    - the original author is the responsible party for all prod changes, but
+      restricting this action to only the original author was too burdensome.
   - workflow: plan
     - taco::plan
     - convert to ready -> plan (and lock)


### PR DESCRIPTION
This was originally to have the PR owner take resposibility for approving. The intention was that if another user wanted to apply, they could close the PR, leaving the branch open, and the open a new PR on that branch which they owned. In practice, however, this proved to be too much friction.

Fixes #259