### PR TITLE
Adds blocklists and per-file filtering.

### DIFF
--- a/lib/tacos/dependent_slices.py
+++ b/lib/tacos/dependent_slices.py
@@ -245,13 +245,19 @@ def lines_to_paths(lines: Iterable[str]) -> Generator[OSPath]:
 def main() -> int:
     import fileinput
 
-    fs = FileSystem.from_git()
-    modified_paths = lines_to_paths(fileinput.input(encoding="utf-8"))
+    file_filter = PathFilter.from_files()
 
-    path_filter = PathFilter.from_config()
+    fs = FileSystem.from_git()
+    modified_paths = [
+        x
+        for x in lines_to_paths(fileinput.input(encoding="utf-8"))
+        if file_filter.match(str(x))
+    ]
+
+    slice_filter = PathFilter.from_slices()
 
     for slice in dependent_slices(modified_paths, fs):
-        if path_filter.match(str(slice)):
+        if slice_filter.match(str(slice)):
             print(slice)
         else:
             sh.debug(f"slice ignored due to allowlist: {slice}")

--- a/lib/tacos/path_filter.py
+++ b/lib/tacos/path_filter.py
@@ -6,7 +6,10 @@ from fnmatch import fnmatch
 
 from lib.types import OSPath
 
-CONFIG_PATH = OSPath(".config/tacos-gha/slices.allowlist")
+SLICE_ALLOW_CONFIG_PATH = OSPath(".config/tacos-gha/slices.allowlist")
+SLICE_BLOCK_CONFIG_PATH = OSPath(".config/tacos-gha/slices.blocklist")
+FILE_ALLOW_CONFIG_PATH = OSPath(".config/tacos-gha/files.allowlist")
+FILE_BLOCK_CONFIG_PATH = OSPath(".config/tacos-gha/files.blocklist")
 
 
 @dataclass(frozen=True)
@@ -14,8 +17,12 @@ class PathFilter:
     """A frozen view of a collection of files."""
 
     allowed: frozenset[str]
+    blocked: frozenset[str]
 
     def match(self, path: str) -> bool:
+        for pattern in self.blocked:
+            if fnmatch(str(path), pattern):
+                return False
         if not self.allowed:
             return True
         for pattern in self.allowed:
@@ -24,30 +31,54 @@ class PathFilter:
         return False
 
     @classmethod
-    def from_config(cls, path: OSPath = CONFIG_PATH) -> PathFilter:
-        """Get a list of allowed globs from a file
+    def from_config(cls, allow_path: OSPath, block_path: OSPath) -> PathFilter:
+        """Get a list of allowed and blocked globs from the config files
 
         Hash comments are removed and blank lines are ignored.
         Inline comments are not allowed
-        An empty or missing file is treated as all allowed.
+        An empty or missing allowlist file allows anything.
+        An empty or missing blocklist file blocks nothing.
+        Blocks take precedence over allows.
         Globs are evaluated with the fnmatch module."""
-        lines: list[str] = []
+        allow_lines: list[str] = []
         # remove from the first unescaped # to the end
         try:
-            with path.open() as config:
-                for line in config:
+            with allow_path.open() as allow_config:
+                for line in allow_config:
                     line = line.strip()
                     if line and not line.startswith("#"):
-                        lines.append(line)
+                        allow_lines.append(line)
         except FileNotFoundError:
             pass
-        return cls(allowed=frozenset(lines))
+        block_lines: list[str] = []
+        # remove from the first unescaped # to the end
+        try:
+            with block_path.open() as block_config:
+                for line in block_config:
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        block_lines.append(line)
+        except FileNotFoundError:
+            pass
+        return cls(
+            allowed=frozenset(allow_lines), blocked=frozenset(block_lines)
+        )
+
+    @classmethod
+    def from_slices(cls) -> PathFilter:
+        return cls.from_config(
+            SLICE_ALLOW_CONFIG_PATH, SLICE_BLOCK_CONFIG_PATH
+        )
+
+    @classmethod
+    def from_files(cls) -> PathFilter:
+        return cls.from_config(FILE_ALLOW_CONFIG_PATH, FILE_BLOCK_CONFIG_PATH)
 
 
 def main() -> int:
     import fileinput
 
-    path_filter = PathFilter.from_config()
+    path_filter = PathFilter.from_slices()
 
     for line in fileinput.input(encoding="utf-8"):
         line = line.strip()


### PR DESCRIPTION
Fixes #274.

The existing path filtering was only an allowlist and only operated on slices. This implements a blocklist that gets applied first and also a filtering step on the raw changed files in the PR, not only on the detected slices.