### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/just-the-basics/action.yml
+++ b/.github/actions/just-the-basics/action.yml
@@ -18,7 +18,7 @@ runs:
 
     # default-shell requires direnv
     - name: install direnv
-      uses: bukzor/direnv-install@v1.1.1/bukzor1
+      uses: bukzor/direnv-install@4cb348d6482fe7c2878782e592d53152bac94f4c # v1.1.1/bukzor1
     - name: show GHA contexts
       shell: ${{inputs.shell}}
       run: |
@@ -57,6 +57,6 @@ runs:
           gha-set-env 'PYTHON_VERSION' \
         ;
     - name: install python ${{env.PYTHON_VERSION}}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{env.PYTHON_VERSION}}

--- a/.github/actions/list-slices/action.yml
+++ b/.github/actions/list-slices/action.yml
@@ -17,7 +17,7 @@ runs:
     - uses: ./tacos-gha/.github/actions/just-the-basics
 
     - id: files
-      uses: dorny/paths-filter@v3.0.1
+      uses: dorny/paths-filter@ebc4d7e9ebcb0b1eb21480bb8f43113e996ac77a # v3.0.1
       with:
         filters: "all: ['**']"
         list-files: json

--- a/.github/actions/matrix-fan-in/action.yml
+++ b/.github/actions/matrix-fan-in/action.yml
@@ -28,7 +28,7 @@ runs:
           tee -a "$GITHUB_ENV"
 
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         pattern: ${{ env.artifact_name }} *${{ inputs.pattern }}*
         path: matrix-fan-in.tmp

--- a/.github/actions/matrix-fan-out/action.yml
+++ b/.github/actions/matrix-fan-out/action.yml
@@ -25,7 +25,7 @@ runs:
           tee -a "$GITHUB_ENV"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ env.artifact_name }}
         path: ${{ inputs.path }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,7 +26,7 @@ runs:
 
     - name: Set up SSH agent
       if: inputs.ssh-private-key != ''
-      uses: webfactory/ssh-agent@v0.8.0
+      uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e # v0.8.0
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}
 
@@ -64,7 +64,7 @@ runs:
 
     - name: gcp auth
       id: auth
-      uses: google-github-actions/auth@v2.1.1
+      uses: google-github-actions/auth@a6e2e39c0a0331da29f7fd2c2a20a427e8d3ad1f # v2.1.1
       with:
         workload_identity_provider: ${{env.GETSENTRY_SAC_OIDC}}
         service_account: ${{env.SUDO_GCP_SERVICE_ACCOUNT}}
@@ -90,12 +90,12 @@ runs:
         gha-set-env 'TERRAGRUNT_VERSION' < "$(nearest-config-file .terragrunt-version)"
 
     - name: Setup Terragrunt
-      uses: autero1/action-terragrunt@v1.3.2
+      uses: autero1/action-terragrunt@916673c030d67131f15d32dab2e527a9339e0897 # v1.3.2
       with:
         terragrunt_version: ${{env.TERRAGRUNT_VERSION}}
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
       with:
         terraform_wrapper: false
         terraform_version: ${{ env.TF_VERSION }}

--- a/.github/workflows/required_check.yml
+++ b/.github/workflows/required_check.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Perform check
         run: |
           if [ -e required_check.fail ]; then exit 1; fi

--- a/.github/workflows/reset-label.yml
+++ b/.github/workflows/reset-label.yml
@@ -29,13 +29,13 @@ jobs:
       LABEL: ${{ inputs.label }}
     steps:
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
           path: tacos-gha
       - name: "Reset label: ${{inputs.label}}"
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         if: always()
         with:
           script: |

--- a/.github/workflows/scratch.yml
+++ b/.github/workflows/scratch.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}

--- a/.github/workflows/selftest-matrix-io.yml
+++ b/.github/workflows/selftest-matrix-io.yml
@@ -48,7 +48,7 @@ jobs:
       KEY: ${{ matrix.key }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: tacos-gha
           sparse-checkout: ".github/actions/matrix-fan-out"
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: tacos-gha
           sparse-checkout: |
@@ -95,7 +95,7 @@ jobs:
         # we want to report failures, too
         if: always()
 
-        uses: thollander/actions-comment-pull-request@v2.4.3
+        uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
         with:
           message: ${{ fromJSON(steps.main.outputs.summary) }}
           comment_tag: selftest-matrix-io

--- a/.github/workflows/tacos_apply.yml
+++ b/.github/workflows/tacos_apply.yml
@@ -50,9 +50,9 @@ jobs:
 
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -85,9 +85,9 @@ jobs:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -117,7 +117,7 @@ jobs:
       # TODO: fetch and apply the tfplan artifact from plan workflow
       # so that apply matches the plan reviewed by construction
       ### - name: fetch tfplan: ${{which}}
-      ###   uses: actions/download-artifact@v4
+      ###   uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       ###   with:
       ###     name: tfplan
       ###     # TODO: github-script to fetch run-id of the most recent tfplan
@@ -146,7 +146,7 @@ jobs:
 
     steps:
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -166,7 +166,7 @@ jobs:
         # we want to report failures, too
         if: always()
 
-        uses: thollander/actions-comment-pull-request@v2.4.3
+        uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
         with:
           message: ${{ fromJSON(steps.summary.outputs.summary) }}
           comment_tag: apply

--- a/.github/workflows/tacos_conflict_detection.yml
+++ b/.github/workflows/tacos_conflict_detection.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}

--- a/.github/workflows/tacos_detect_drift.yml
+++ b/.github/workflows/tacos_detect_drift.yml
@@ -42,9 +42,9 @@ jobs:
 
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -74,9 +74,9 @@ jobs:
       TF_ROOT_MODULES: ${{needs.determine-tf-root-modules.outputs.slices}}
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -53,9 +53,9 @@ jobs:
 
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -88,9 +88,9 @@ jobs:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -165,7 +165,7 @@ jobs:
         # we want to report failures, too
         if: always()
 
-        uses: thollander/actions-comment-pull-request@v2.4.3
+        uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
         with:
           message: ${{ fromJSON(steps.summary.outputs.summary) }}
           comment_tag: plan

--- a/.github/workflows/tacos_unlock.yml
+++ b/.github/workflows/tacos_unlock.yml
@@ -44,9 +44,9 @@ jobs:
 
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -79,9 +79,9 @@ jobs:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}
     steps:
       - name: Checkout IAC
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Checkout tacos-gha
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{inputs.tacos_gha_repo}}
           ref: ${{inputs.tacos_gha_ref}}
@@ -150,7 +150,7 @@ jobs:
         # we want to report failures, too
         if: always()
 
-        uses: thollander/actions-comment-pull-request@v2.4.3
+        uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
         with:
           message: ${{ fromJSON(steps.summary.outputs.summary) }}
           comment_tag: unlock


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)