### PR TITLE
fix: handle TG 1.x log prefixes in apply/plan summary classification

### DIFF
--- a/lib/ci/bin/tf-step-summary
+++ b/lib/ci/bin/tf-step-summary
@@ -46,7 +46,7 @@ save_legacy_summary() {
   explanation="$1"
 
   summary="$(
-    if tac "$tf_log" | uncolor | grep -E -m1 '^(Apply complete|Plan:|No changes)'; then
+    if tac "$tf_log" | uncolor | grep -E -m1 '(Apply complete|Plan:|No changes)'; then
       : :D
     elif cat "$console_log" "$tf_log" | uncolor | grep -E -m1 'error|Error|ERROR'; then
       : D:

--- a/lib/ci/tacos_summary.py
+++ b/lib/ci/tacos_summary.py
@@ -130,6 +130,15 @@ class SliceSummary(NamedTuple):
 
             yield cls.from_matrix_fan_out(path / matrix)
 
+    def _in_any_log_line(self, needle: str) -> bool:
+        """Substring search across tf_log lines.
+
+        TG 1.x prefixes stdout lines with structured logging
+        (e.g. "14:14:06.505 STDOUT [.] terraform: No changes..."),
+        so exact tuple membership ("needle" in self.tf_log) no longer works.
+        """
+        return any(needle in line for line in self.tf_log)
+
     @property
     def dirty(self) -> bool:
         """The tf-plan is nonempty."""
@@ -139,9 +148,8 @@ class SliceSummary(NamedTuple):
     def clean(self) -> bool:
         """The job succeeded."""
         if self.tacos_verb == "apply":
-            if (
+            if self._in_any_log_line(
                 "No changes. Your infrastructure matches the configuration."
-                in self.tf_log
             ):
                 return self.returncode == 0
             else:
@@ -152,9 +160,8 @@ class SliceSummary(NamedTuple):
     @property
     def applied(self) -> bool:
         """The job succeeded and made changes."""
-        if (
-            self.tacos_verb == "apply"
-            and "Terraform will perform the following actions:" in self.tf_log
+        if self.tacos_verb == "apply" and self._in_any_log_line(
+            "Terraform will perform the following actions:"
         ):
             return self.returncode == 0
         else:


### PR DESCRIPTION
## Summary

Fixes #306

- Terragrunt 1.x wraps terraform stdout with structured log prefixes (e.g. `14:14:06.505 STDOUT [.] terraform: Apply complete!...`) when using `run --all`. The `clean` and `applied` properties on `SliceSummary` used exact tuple membership checks (`"string" in self.tf_log`) which fail against prefixed lines, causing apply summaries to report "0 slices".
- Switches to substring matching within individual log lines, searching both `tf_log` and `console_log`. Also drops the `^` anchor in `tf-step-summary` grep so it matches prefixed lines in the legacy summary path.
- Backward-compatible: works correctly for both TG 0.54.x (no prefix) and TG 1.x (with prefix).

## Test plan

- [x] Verify existing unit tests pass (`tacos_summary_test.py`, `tacos_plan_summary_test.py`)
- [ ] Trigger a plan and apply on a TG 1.x slice (e.g. kafka) and verify the PR comment summary correctly classifies slices as clean/applied/error
- [ ] Trigger a plan and apply on a TG 0.54.x slice and verify no regression