### PR TITLE
fix: use version prefix match for Terragrunt 0.x

### DIFF
--- a/lib/tacos/apply
+++ b/lib/tacos/apply
@@ -8,7 +8,7 @@ exec 3>&1 1>&2
   sudo-gcp tf-lock-acquire
 )
 
-if [ "${TERRAGRUNT_VERSION}" = "0.54.15" ]; then
+if [[ "${TERRAGRUNT_VERSION}" == 0.* ]]; then
     run_all=("run-all")
 else
     run_all=("run" "--all" "--")

--- a/lib/tacos/plan
+++ b/lib/tacos/plan
@@ -7,7 +7,7 @@ exec 3>&1 1>&2
 # note: for terragrunt, tfplan must be absolute
 TACOS_TFPLAN="${TACOS_TFPLAN:-$PWD/tfplan}"
 TACOS_LOCK="${TACOS_LOCK:-false}"
-if [ "${TERRAGRUNT_VERSION}" = "0.54.15" ]; then
+if [[ "${TERRAGRUNT_VERSION}" == 0.* ]]; then
     run_all=("run-all")
 else
     run_all=("run" "--all" "--")

--- a/lib/tf_lock/lib/env.py
+++ b/lib/tf_lock/lib/env.py
@@ -51,7 +51,7 @@ path_prepend("PATH", TACOS_GHA_HOME + "/lib/tf_lock/bin")
 def tf_working_dir(root_module: OSPath) -> Path:
     if (root_module / "terragrunt.hcl").exists():
         with sh.cd(root_module):
-            if TERRAGRUNT_VERSION == "0.54.15":
+            if TERRAGRUNT_VERSION.startswith("0."):
                 working_dir_key = "WorkingDir"
                 # validate-inputs makes terragrunt generate its templates
                 sh.run((

--- a/lib/tf_lock/lib/env.sh
+++ b/lib/tf_lock/lib/env.sh
@@ -18,7 +18,7 @@ tf_working_dir() {
   root_module="$1"
   if [[ -e "$root_module/terragrunt.hcl" ]]; then
     ( cd "$root_module"
-      if [ "${TERRAGRUNT_VERSION}" = "0.54.15" ]; then
+      if [[ "${TERRAGRUNT_VERSION}" == 0.* ]]; then
         # validate-inputs makes terragrunt generate its templates
         terragrunt --terragrunt-no-auto-init=false validate-inputs
 

--- a/lib/tf_lock/release.py
+++ b/lib/tf_lock/release.py
@@ -164,7 +164,7 @@ def tf_working_dir(root_module: Path) -> Path:
 
     if OSPath(root_module / "terragrunt.hcl").exists():
         with sh.cd(root_module):
-            if TERRAGRUNT_VERSION == "0.54.15":
+            if TERRAGRUNT_VERSION.startswith("0."):
                 working_dir_key = "WorkingDir"
                 sh.run(("terragrunt", "validate-inputs"))
                 info = sh.json(("terragrunt", "terragrunt-info"))


### PR DESCRIPTION
The exact-match check against "0.54.15" caused all other 0.x versions (e.g. 0.57.2) to incorrectly use TG 1.x commands, failing with "Terraform has no command named hcl".

Context:
- All TACOS Plan CI checks are failing in `terraform-sandboxes.private` with `Terraform has no command named "hcl"` because the repo pins `TERRAGRUNT_VERSION=0.57.2`
- The regression was introduced in PR #302 (`0a5aca0`), which added TG 1.x command support but hard-coded the version check to only match `0.54.15` — any other 0.x version fell into the 1.x code path
- Changed to prefix match (`0.*` / `startswith("0.")`) across 5 files so all 0.x versions use old-style commands and only 1.x+ uses new-style commands