### PR TITLE
feat: add Datadog secret inputs to reusable workflows

### DIFF
--- a/.github/workflows/tacos_apply.yml
+++ b/.github/workflows/tacos_apply.yml
@@ -17,6 +17,12 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      DD_API_KEY:
+        description: "Datadog API key for Terraform provider"
+        required: false
+      DD_APP_KEY:
+        description: "Datadog App key for Terraform provider"
+        required: false
 
 defaults:
   run:
@@ -83,6 +89,8 @@ jobs:
 
     env:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
     steps:
       - name: Checkout IAC
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/tacos_detect_drift.yml
+++ b/.github/workflows/tacos_detect_drift.yml
@@ -17,6 +17,12 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      DD_API_KEY:
+        description: "Datadog API key for Terraform provider"
+        required: false
+      DD_APP_KEY:
+        description: "Datadog App key for Terraform provider"
+        required: false
 
 defaults:
   run:
@@ -72,6 +78,8 @@ jobs:
 
     env:
       TF_ROOT_MODULES: ${{needs.determine-tf-root-modules.outputs.slices}}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
     steps:
       - name: Checkout IAC
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -20,6 +20,12 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      DD_API_KEY:
+        description: "Datadog API key for Terraform provider"
+        required: false
+      DD_APP_KEY:
+        description: "Datadog App key for Terraform provider"
+        required: false
 
 defaults:
   run:
@@ -86,6 +92,8 @@ jobs:
 
     env:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
     steps:
       - name: Checkout IAC
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Cherry-pick of #311 (targeting `stable`) onto `main`
- Adds `DD_API_KEY` and `DD_APP_KEY` as optional secret inputs to `tacos_plan`, `tacos_apply`, and `tacos_detect_drift` reusable workflows
- Exposes those secrets as env vars in the jobs that run Terraform, so the downstream `.envrc` can pick them up for the Datadog Terraform provider

## Context
The `getsentry/ops` repo's `.envrc` reads `DD_API_KEY` and `DD_APP_KEY` from the environment in CI to configure the Datadog Terraform provider. Without these secret declarations, callers cannot forward their Datadog credentials through `secrets:`, causing `401 Unauthorized` errors on any Terraform plan/apply that touches Datadog monitors.

Companion PR: https://github.com/getsentry/ops/pull/21355

## Test plan
- [x] Verify that `getsentry/ops` Terraform Plan workflow succeeds on a PR touching Datadog monitors after both PRs are merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Agent transcript: https://claudescope.sentry.dev/share/oC96H9cZkyD_X90L7p4GhE6gfjfUU69HgR69JUrMakM