### PR TITLE
Add .tacos-disabled sentinel file to skip slices

### DIFF
--- a/.github/actions/list-slices/action.yml
+++ b/.github/actions/list-slices/action.yml
@@ -9,6 +9,9 @@ outputs:
   slices:
     description: "JSON list of paths to relevant TF/TG slices"
     value: ${{ steps.list-slices.outputs.slices }}
+  disabled_slices:
+    description: "JSON list of disabled slices with messages"
+    value: ${{ steps.list-slices.outputs.disabled_slices }}
 
 runs:
   using: composite

--- a/.github/actions/notify-disabled-slices/action.yml
+++ b/.github/actions/notify-disabled-slices/action.yml
@@ -13,6 +13,8 @@ runs:
       id: render
       if: inputs.disabled_slices != '[]'
       shell: bash
+      env:
+        DISABLED_SLICES: ${{ inputs.disabled_slices }}
       run: |
         comment="### ⚠️ Disabled Slices"
         comment+=$'\n\n'
@@ -24,7 +26,7 @@ runs:
           message="$(echo "$line" | jq -r '.message')"
           comment+="- \`${slice}\` — ${message}"
           comment+=$'\n'
-        done < <(echo '${{ inputs.disabled_slices }}' | jq -c '.[]')
+        done < <(echo "$DISABLED_SLICES" | jq -c '.[]')
 
         {
           echo "comment<<TACOS_EOF"
@@ -32,10 +34,18 @@ runs:
           echo "TACOS_EOF"
         } >> "$GITHUB_OUTPUT"
 
-    - name: Notify Disabled Slices
+    - name: Post Disabled Slices Comment
       if: inputs.disabled_slices != '[]'
       uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
       with:
         comment_tag: tacos-disabled
         mode: recreate
         message: ${{ steps.render.outputs.comment }}
+
+    - name: Remove Stale Disabled Slices Comment
+      if: inputs.disabled_slices == '[]'
+      uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
+      with:
+        comment_tag: tacos-disabled
+        mode: delete
+        message: ""

--- a/.github/actions/notify-disabled-slices/action.yml
+++ b/.github/actions/notify-disabled-slices/action.yml
@@ -28,10 +28,11 @@ runs:
           comment+=$'\n'
         done < <(echo "$DISABLED_SLICES" | jq -c '.[]')
 
+        delimiter="TACOS_$(openssl rand -hex 8)"
         {
-          echo "comment<<TACOS_EOF"
+          echo "comment<<${delimiter}"
           echo "$comment"
-          echo "TACOS_EOF"
+          echo "${delimiter}"
         } >> "$GITHUB_OUTPUT"
 
     - name: Post Disabled Slices Comment

--- a/.github/actions/notify-disabled-slices/action.yml
+++ b/.github/actions/notify-disabled-slices/action.yml
@@ -1,0 +1,41 @@
+name: Notify Disabled Slices
+
+inputs:
+  disabled_slices:
+    description: "JSON list of disabled slices from list-slices action"
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Render Comment
+      id: render
+      if: inputs.disabled_slices != '[]'
+      shell: bash
+      run: |
+        comment="### ⚠️ Disabled Slices"
+        comment+=$'\n\n'
+        comment+="The following slices in this PR are **disabled** in TACOS-GHA and will not be planned or applied:"
+        comment+=$'\n\n'
+
+        while IFS= read -r line; do
+          slice="$(echo "$line" | jq -r '.slice')"
+          message="$(echo "$line" | jq -r '.message')"
+          comment+="- \`${slice}\` — ${message}"
+          comment+=$'\n'
+        done < <(echo '${{ inputs.disabled_slices }}' | jq -c '.[]')
+
+        {
+          echo "comment<<TACOS_EOF"
+          echo "$comment"
+          echo "TACOS_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Notify Disabled Slices
+      if: inputs.disabled_slices != '[]'
+      uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
+      with:
+        comment_tag: tacos-disabled
+        mode: recreate
+        message: ${{ steps.render.outputs.comment }}

--- a/.github/actions/notify-disabled-slices/action.yml
+++ b/.github/actions/notify-disabled-slices/action.yml
@@ -44,6 +44,7 @@ runs:
 
     - name: Remove Stale Disabled Slices Comment
       if: inputs.disabled_slices == '[]'
+      continue-on-error: true
       uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
       with:
         comment_tag: tacos-disabled

--- a/.github/actions/notify-disabled-slices/action.yml
+++ b/.github/actions/notify-disabled-slices/action.yml
@@ -37,17 +37,15 @@ runs:
 
     - name: Post Disabled Slices Comment
       if: inputs.disabled_slices != '[]'
-      uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
-        comment_tag: tacos-disabled
+        comment-tag: tacos-disabled
         mode: recreate
         message: ${{ steps.render.outputs.comment }}
 
     - name: Remove Stale Disabled Slices Comment
       if: inputs.disabled_slices == '[]'
-      continue-on-error: true
-      uses: thollander/actions-comment-pull-request@1d3973dc4b8e1399c0620d3f2b1aa5e795465308 # v2.4.3
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
-        comment_tag: tacos-disabled
+        comment-tag: tacos-disabled
         mode: delete
-        message: ""

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -71,6 +71,11 @@ jobs:
         id: list-slices
         uses: ./tacos-gha/.github/actions/list-slices
 
+      - name: Notify Disabled Slices
+        uses: ./tacos-gha/.github/actions/notify-disabled-slices
+        with:
+          disabled_slices: ${{ steps.list-slices.outputs.disabled_slices }}
+
   tacos_plan:
     name: TACOS Plan
     needs: [determine-tf-root-modules]

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -72,6 +72,7 @@ jobs:
         uses: ./tacos-gha/.github/actions/list-slices
 
       - name: Notify Disabled Slices
+        continue-on-error: true
         uses: ./tacos-gha/.github/actions/notify-disabled-slices
         with:
           disabled_slices: ${{ steps.list-slices.outputs.disabled_slices }}

--- a/.github/workflows/tacos_unlock.yml
+++ b/.github/workflows/tacos_unlock.yml
@@ -42,6 +42,9 @@ jobs:
       contents: read
       pull-requests: write
 
+    env:
+      TACOS_IGNORE_DISABLED: "1"
+
     steps:
       - name: Checkout IAC
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -35,6 +35,30 @@ These allowlists can consist of empty lines, comments where the first character
 of the line is a #, and patterns that will be matched to slices with with
 python's [fnmatch module](https://docs.python.org/3/library/fnmatch.html).
 
+## Disabling TACOS-GHA for a slice
+
+To disable TACOS-GHA for a specific slice or subtree, create an empty
+`.tacos-disabled` sentinel file in the target directory. TACOS-GHA will skip
+any slice that contains a `.tacos-disabled` file in its directory or any
+ancestor directory. This is useful for incrementally retiring slices from
+TACOS-GHA management.
+
+For example, to disable all slices under `terragrunt/regions/multi-tenant/kafka/`:
+
+```
+touch terragrunt/regions/multi-tenant/kafka/.tacos-disabled
+git add terragrunt/regions/multi-tenant/kafka/.tacos-disabled
+```
+
+To disable a single slice:
+
+```
+touch terragrunt/regions/multi-tenant/kafka/snuba-errors/us/.tacos-disabled
+git add terragrunt/regions/multi-tenant/kafka/snuba-errors/us/.tacos-disabled
+```
+
+The sentinel file must be committed and tracked by git to take effect.
+
 # Usage
 
 ## The Pull Request

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -59,6 +59,11 @@ git add terragrunt/regions/multi-tenant/kafka/snuba-errors/us/.tacos-disabled
 
 The sentinel file must be committed and tracked by git to take effect.
 
+**Note:** Do not add `.tacos-disabled` to a slice that is currently locked by
+an open pull request. The unlock workflow also respects the sentinel, so a
+locked slice that becomes disabled will not be automatically unlocked when its
+PR is closed. Release any TACOS-GHA locks before disabling a slice.
+
 # Usage
 
 ## The Pull Request

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -65,7 +65,7 @@ If a PR touches disabled slices, TACOS-GHA will post a comment listing them.
 To customize the message, write it into the `.tacos-disabled` file:
 
 ```
-echo "This slice is now managed by Spacelift." > terragrunt/regions/multi-tenant/kafka/.tacos-disabled
+echo "This slice is now managed externally." > terragrunt/regions/multi-tenant/kafka/.tacos-disabled
 ```
 
 An empty file uses a default message.

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -61,6 +61,15 @@ The sentinel file must be committed and tracked by git to take effect. The
 unlock workflow ignores the sentinel so that locks on disabled slices are
 still released when a pull request is closed or converted to draft.
 
+If a PR touches disabled slices, TACOS-GHA will post a comment listing them.
+To customize the message, write it into the `.tacos-disabled` file:
+
+```
+echo "This slice is now managed by Spacelift." > terragrunt/regions/multi-tenant/kafka/.tacos-disabled
+```
+
+An empty file uses a default message.
+
 # Usage
 
 ## The Pull Request

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -57,12 +57,9 @@ touch terragrunt/regions/multi-tenant/kafka/snuba-errors/us/.tacos-disabled
 git add terragrunt/regions/multi-tenant/kafka/snuba-errors/us/.tacos-disabled
 ```
 
-The sentinel file must be committed and tracked by git to take effect.
-
-**Note:** Do not add `.tacos-disabled` to a slice that is currently locked by
-an open pull request. The unlock workflow also respects the sentinel, so a
-locked slice that becomes disabled will not be automatically unlocked when its
-PR is closed. Release any TACOS-GHA locks before disabling a slice.
+The sentinel file must be committed and tracked by git to take effect. The
+unlock workflow ignores the sentinel so that locks on disabled slices are
+still released when a pull request is closed or converted to draft.
 
 # Usage
 

--- a/lib/ci/list-slices
+++ b/lib/ci/list-slices
@@ -2,6 +2,9 @@
 # stdin: json listing of all files editted
 set -euo pipefail
 
+export TACOS_DISABLED_FILE
+TACOS_DISABLED_FILE="$(mktemp)"
+
 jq '.[]' --raw-output |
   python3.12 -P -m lib.tacos.dependent_slices |
   # transform newline-delimited list into json:
@@ -12,3 +15,12 @@ jq '.[]' --raw-output |
   # prettify
   jq . \
 ;
+
+if [ -s "$TACOS_DISABLED_FILE" ]; then
+  jq -c '.' "$TACOS_DISABLED_FILE" |
+    gha-set-output disabled_slices
+else
+  echo '[]' | gha-set-output disabled_slices
+fi
+
+rm -f "$TACOS_DISABLED_FILE"

--- a/lib/tacos/dependent_slices.py
+++ b/lib/tacos/dependent_slices.py
@@ -255,7 +255,7 @@ def main() -> int:
     for slice in dependent_slices(modified_paths, fs):
         if not ignore_disabled and path_filter.is_disabled(str(slice), fs.files):
             sh.debug(f"slice disabled by .tacos-disabled: {slice}")
-        elif path_filter.match(str(slice), fs.files):
+        elif path_filter.match(str(slice)):
             print(slice)
         else:
             sh.debug(f"slice ignored due to allowlist: {slice}")

--- a/lib/tacos/dependent_slices.py
+++ b/lib/tacos/dependent_slices.py
@@ -244,7 +244,9 @@ def lines_to_paths(lines: Iterable[str]) -> Generator[OSPath]:
 
 def main() -> int:
     import fileinput
+    import json
     import os
+    import sys
 
     fs = FileSystem.from_git()
     modified_paths = lines_to_paths(fileinput.input(encoding="utf-8"))
@@ -252,13 +254,24 @@ def main() -> int:
     path_filter = PathFilter.from_config()
     ignore_disabled = bool(os.environ.get("TACOS_IGNORE_DISABLED"))
 
+    disabled: list[dict[str, str]] = []
+
     for slice in dependent_slices(modified_paths, fs):
         if not ignore_disabled and path_filter.is_disabled(str(slice), fs.files):
             sh.debug(f"slice disabled by .tacos-disabled: {slice}")
+            disabled.append({
+                "slice": str(slice),
+                "message": path_filter.disabled_message(str(slice)),
+            })
         elif path_filter.match(str(slice)):
             print(slice)
         else:
             sh.debug(f"slice ignored due to allowlist: {slice}")
+
+    disabled_file = os.environ.get("TACOS_DISABLED_FILE")
+    if disabled_file:
+        with open(disabled_file, "w") as f:
+            json.dump(disabled, f)
 
     return 0
 

--- a/lib/tacos/dependent_slices.py
+++ b/lib/tacos/dependent_slices.py
@@ -244,14 +244,16 @@ def lines_to_paths(lines: Iterable[str]) -> Generator[OSPath]:
 
 def main() -> int:
     import fileinput
+    import os
 
     fs = FileSystem.from_git()
     modified_paths = lines_to_paths(fileinput.input(encoding="utf-8"))
 
     path_filter = PathFilter.from_config()
+    ignore_disabled = bool(os.environ.get("TACOS_IGNORE_DISABLED"))
 
     for slice in dependent_slices(modified_paths, fs):
-        if path_filter.is_disabled(str(slice), fs.files):
+        if not ignore_disabled and path_filter.is_disabled(str(slice), fs.files):
             sh.debug(f"slice disabled by .tacos-disabled: {slice}")
         elif path_filter.match(str(slice), fs.files):
             print(slice)

--- a/lib/tacos/dependent_slices.py
+++ b/lib/tacos/dependent_slices.py
@@ -251,7 +251,9 @@ def main() -> int:
     path_filter = PathFilter.from_config()
 
     for slice in dependent_slices(modified_paths, fs):
-        if path_filter.match(str(slice)):
+        if path_filter.is_disabled(str(slice), fs.files):
+            sh.debug(f"slice disabled by .tacos-disabled: {slice}")
+        elif path_filter.match(str(slice), fs.files):
             print(slice)
         else:
             sh.debug(f"slice ignored due to allowlist: {slice}")

--- a/lib/tacos/dependent_slices_test.py
+++ b/lib/tacos/dependent_slices_test.py
@@ -166,6 +166,34 @@ class TestDependentSlices:
         )
 
 
+class TestDisabledSentinel:
+    def test_disabled_slice_excluded_from_fs(self) -> None:
+        paths = (
+            OSPath("terraform/slice-0/main.tf"),
+            OSPath("terraform/slice-0/.tacos-disabled"),
+            OSPath("terraform/slice-1/main.tf"),
+        )
+        fs = D.FileSystem.from_paths(paths)
+        categorized = D.TFCategorized.from_fs(fs)
+        assert categorized.slices == frozenset({
+            D.TopLevelTFModule(D.TFModule(D.Dir(Path("terraform/slice-0")))),
+            D.TopLevelTFModule(D.TFModule(D.Dir(Path("terraform/slice-1")))),
+        })
+
+    def test_sentinel_does_not_affect_categorization(self) -> None:
+        """The sentinel is a filter, not a categorization concern.
+        TFCategorized still sees disabled slices; filtering happens later."""
+        paths = (
+            OSPath("env/prod/slice-0/thing.tf"),
+            OSPath("env/prod/slice-0/.tacos-disabled"),
+        )
+        fs = D.FileSystem.from_paths(paths)
+        categorized = D.TFCategorized.from_fs(fs)
+        assert D.TopLevelTFModule(
+            D.TFModule(D.Dir(Path("env/prod/slice-0")))
+        ) in categorized.slices
+
+
 class TestRegressions:
     """Real-world cases that (initially) weren't caught by unit-tests."""
 

--- a/lib/tacos/dependent_slices_test.py
+++ b/lib/tacos/dependent_slices_test.py
@@ -167,7 +167,8 @@ class TestDependentSlices:
 
 
 class TestDisabledSentinel:
-    def test_disabled_slice_excluded_from_fs(self) -> None:
+    def test_disabled_slice_still_in_categorized(self) -> None:
+        """TFCategorized sees all slices; .tacos-disabled filtering is separate."""
         paths = (
             OSPath("terraform/slice-0/main.tf"),
             OSPath("terraform/slice-0/.tacos-disabled"),

--- a/lib/tacos/path_filter.py
+++ b/lib/tacos/path_filter.py
@@ -27,7 +27,8 @@ class PathFilter:
     def _is_disabled_from_disk(self, path: str) -> bool:
         p = OSPath(path)
         for ancestor in (p, *p.parents):
-            if (ancestor / self.disabled_sentinel).is_file():
+            sentinel = ancestor / self.disabled_sentinel
+            if sentinel.is_file() and not sentinel.is_symlink():
                 return True
         return False
 
@@ -43,7 +44,7 @@ class PathFilter:
         p = OSPath(path)
         for ancestor in (p, *p.parents):
             sentinel = ancestor / self.disabled_sentinel
-            if sentinel.is_file():
+            if sentinel.is_file() and not sentinel.is_symlink():
                 content = sentinel.read_text().strip()
                 if content:
                     return content

--- a/lib/tacos/path_filter.py
+++ b/lib/tacos/path_filter.py
@@ -5,8 +5,10 @@ from dataclasses import dataclass
 from fnmatch import fnmatch
 
 from lib.types import OSPath
+from lib.types import Path
 
 CONFIG_PATH = OSPath(".config/tacos-gha/slices.allowlist")
+DISABLED_SENTINEL = ".tacos-disabled"
 
 
 @dataclass(frozen=True)
@@ -14,8 +16,31 @@ class PathFilter:
     """A frozen view of a collection of files."""
 
     allowed: frozenset[str]
+    disabled_sentinel: str = DISABLED_SENTINEL
 
-    def match(self, path: str) -> bool:
+    def is_disabled(self, path: str, fs_files: frozenset[Path] | None = None) -> bool:
+        """Check if a slice is disabled by a sentinel file in it or any ancestor."""
+        if fs_files is not None:
+            return self._is_disabled_from_fs(path, fs_files)
+        return self._is_disabled_from_disk(path)
+
+    def _is_disabled_from_disk(self, path: str) -> bool:
+        p = OSPath(path)
+        for ancestor in (p, *p.parents):
+            if (ancestor / self.disabled_sentinel).is_file():
+                return True
+        return False
+
+    def _is_disabled_from_fs(self, path: str, fs_files: frozenset[Path]) -> bool:
+        p = Path(path)
+        for ancestor in (p, *p.parents):
+            if Path(str(ancestor / self.disabled_sentinel)) in fs_files:
+                return True
+        return False
+
+    def match(self, path: str, fs_files: frozenset[Path] | None = None) -> bool:
+        if self.is_disabled(path, fs_files):
+            return False
         if not self.allowed:
             return True
         for pattern in self.allowed:
@@ -47,6 +72,8 @@ class PathFilter:
 def main() -> int:
     import fileinput
 
+    from lib.sh import sh
+
     path_filter = PathFilter.from_config()
 
     for line in fileinput.input(encoding="utf-8"):
@@ -54,7 +81,9 @@ def main() -> int:
         if not line or line.startswith("#"):
             continue
 
-        if path_filter.match(line):
+        if path_filter.is_disabled(line):
+            sh.debug(f"slice disabled by {DISABLED_SENTINEL}: {line}")
+        elif path_filter.match(line):
             print(line)
 
     return 0

--- a/lib/tacos/path_filter.py
+++ b/lib/tacos/path_filter.py
@@ -35,7 +35,8 @@ class PathFilter:
     def _is_disabled_from_fs(self, path: str, fs_files: frozenset[Path]) -> bool:
         p = Path(path)
         for ancestor in (p, *p.parents):
-            if Path(str(ancestor / self.disabled_sentinel)) in fs_files:
+            sentinel = Path(str(ancestor / self.disabled_sentinel))
+            if sentinel in fs_files and not OSPath(sentinel).is_symlink():
                 return True
         return False
 

--- a/lib/tacos/path_filter.py
+++ b/lib/tacos/path_filter.py
@@ -38,6 +38,18 @@ class PathFilter:
                 return True
         return False
 
+    def disabled_message(self, path: str) -> str:
+        """Read the content of the nearest .tacos-disabled sentinel file."""
+        p = OSPath(path)
+        for ancestor in (p, *p.parents):
+            sentinel = ancestor / self.disabled_sentinel
+            if sentinel.is_file():
+                content = sentinel.read_text().strip()
+                if content:
+                    return content
+                break
+        return "This slice has been disabled in TACOS-GHA."
+
     def match(self, path: str) -> bool:
         if not self.allowed:
             return True

--- a/lib/tacos/path_filter.py
+++ b/lib/tacos/path_filter.py
@@ -38,9 +38,7 @@ class PathFilter:
                 return True
         return False
 
-    def match(self, path: str, fs_files: frozenset[Path] | None = None) -> bool:
-        if self.is_disabled(path, fs_files):
-            return False
+    def match(self, path: str) -> bool:
         if not self.allowed:
             return True
         for pattern in self.allowed:

--- a/lib/tacos/path_filter_test.py
+++ b/lib/tacos/path_filter_test.py
@@ -90,6 +90,19 @@ class TestPathFilterDisabled:
         (slice_dir / ".tacos-disabled").symlink_to(target)
         assert not pf._is_disabled_from_disk(str(slice_dir))
 
+    def test_symlink_sentinel_ignored_from_fs(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        target = tmp_path / "secret"
+        target.write_text("token=s3cret")
+        (slice_dir / ".tacos-disabled").symlink_to(target)
+        fs_files: frozenset[Path] = frozenset({
+            Path(str(slice_dir / "main.tf")),
+            Path(str(slice_dir / ".tacos-disabled")),
+        })
+        assert not pf.is_disabled(str(slice_dir), fs_files)
+
     def test_symlink_sentinel_message_returns_default(self, tmp_path: OSPath) -> None:
         pf = PathFilter(allowed=frozenset())
         slice_dir = tmp_path / "terraform" / "slice-0"

--- a/lib/tacos/path_filter_test.py
+++ b/lib/tacos/path_filter_test.py
@@ -40,20 +40,10 @@ class TestPathFilterDisabled:
         assert pf.is_disabled("terraform/slice-0", fs_files)
         assert not pf.is_disabled("terraform/slice-1", fs_files)
 
-    def test_match_returns_false_when_disabled(self) -> None:
+    def test_match_ignores_disabled(self) -> None:
+        """match() only checks the allowlist; disabled filtering is the caller's job."""
         pf = PathFilter(allowed=frozenset({"terraform/*"}))
-        fs_files: frozenset[Path] = frozenset({
-            Path("terraform/slice-0/main.tf"),
-            Path("terraform/slice-0/.tacos-disabled"),
-        })
-        assert not pf.match("terraform/slice-0", fs_files)
-
-    def test_match_returns_true_when_not_disabled(self) -> None:
-        pf = PathFilter(allowed=frozenset({"terraform/*"}))
-        fs_files: frozenset[Path] = frozenset({
-            Path("terraform/slice-0/main.tf"),
-        })
-        assert pf.match("terraform/slice-0", fs_files)
+        assert pf.match("terraform/slice-0")
 
     def test_disabled_at_disk(self, tmp_path: OSPath) -> None:
         pf = PathFilter(allowed=frozenset())

--- a/lib/tacos/path_filter_test.py
+++ b/lib/tacos/path_filter_test.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from lib.types import OSPath
+from lib.types import Path
+
+from .path_filter import PathFilter
+
+
+class TestPathFilterDisabled:
+    def test_not_disabled_by_default(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+        })
+        assert not pf.is_disabled("terraform/slice-0", fs_files)
+
+    def test_disabled_by_sentinel_in_slice(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+            Path("terraform/slice-0/.tacos-disabled"),
+        })
+        assert pf.is_disabled("terraform/slice-0", fs_files)
+
+    def test_disabled_by_sentinel_in_parent(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+            Path("terraform/.tacos-disabled"),
+        })
+        assert pf.is_disabled("terraform/slice-0", fs_files)
+
+    def test_disabled_does_not_affect_sibling(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+            Path("terraform/slice-0/.tacos-disabled"),
+            Path("terraform/slice-1/main.tf"),
+        })
+        assert pf.is_disabled("terraform/slice-0", fs_files)
+        assert not pf.is_disabled("terraform/slice-1", fs_files)
+
+    def test_match_returns_false_when_disabled(self) -> None:
+        pf = PathFilter(allowed=frozenset({"terraform/*"}))
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+            Path("terraform/slice-0/.tacos-disabled"),
+        })
+        assert not pf.match("terraform/slice-0", fs_files)
+
+    def test_match_returns_true_when_not_disabled(self) -> None:
+        pf = PathFilter(allowed=frozenset({"terraform/*"}))
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+        })
+        assert pf.match("terraform/slice-0", fs_files)
+
+    def test_disabled_at_disk(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        (slice_dir / ".tacos-disabled").touch()
+        assert pf._is_disabled_from_disk(str(slice_dir))
+
+    def test_not_disabled_at_disk(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        assert not pf._is_disabled_from_disk(str(slice_dir))
+
+
+class TestPathFilterAllowlist:
+    def test_empty_allows_all(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        assert pf.match("anything/at/all")
+
+    def test_pattern_match(self) -> None:
+        pf = PathFilter(allowed=frozenset({"terraform/*"}))
+        assert pf.match("terraform/slice-0")
+        assert not pf.match("other/slice-0")

--- a/lib/tacos/path_filter_test.py
+++ b/lib/tacos/path_filter_test.py
@@ -58,6 +58,29 @@ class TestPathFilterDisabled:
         slice_dir.mkdir(parents=True)
         assert not pf._is_disabled_from_disk(str(slice_dir))
 
+    def test_disabled_message_custom(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        (slice_dir / ".tacos-disabled").write_text("Managed by Spacelift now.")
+        assert pf.disabled_message(str(slice_dir)) == "Managed by Spacelift now."
+
+    def test_disabled_message_default(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        (slice_dir / ".tacos-disabled").touch()
+        assert pf.disabled_message(str(slice_dir)) == "This slice has been disabled in TACOS-GHA."
+
+    def test_disabled_message_from_parent(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        parent = tmp_path / "terraform"
+        parent.mkdir(parents=True)
+        (parent / ".tacos-disabled").write_text("Entire subtree migrated.")
+        slice_dir = parent / "slice-0"
+        slice_dir.mkdir()
+        assert pf.disabled_message(str(slice_dir)) == "Entire subtree migrated."
+
 
 class TestPathFilterAllowlist:
     def test_empty_allows_all(self) -> None:

--- a/lib/tacos/path_filter_test.py
+++ b/lib/tacos/path_filter_test.py
@@ -81,6 +81,24 @@ class TestPathFilterDisabled:
         slice_dir.mkdir()
         assert pf.disabled_message(str(slice_dir)) == "Entire subtree migrated."
 
+    def test_symlink_sentinel_ignored_on_disk(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        target = tmp_path / "secret"
+        target.write_text("token=s3cret")
+        (slice_dir / ".tacos-disabled").symlink_to(target)
+        assert not pf._is_disabled_from_disk(str(slice_dir))
+
+    def test_symlink_sentinel_message_returns_default(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        target = tmp_path / "secret"
+        target.write_text("token=s3cret")
+        (slice_dir / ".tacos-disabled").symlink_to(target)
+        assert pf.disabled_message(str(slice_dir)) == "This slice has been disabled in TACOS-GHA."
+
 
 class TestPathFilterAllowlist:
     def test_empty_allows_all(self) -> None:


### PR DESCRIPTION
## Summary

- Adds a `.tacos-disabled` sentinel file mechanism to skip slices from TACOS-GHA management (plan, apply, drift detection)
- The unlock workflow intentionally ignores the sentinel so locks on disabled slices are still released
- When a PR touches disabled slices, TACOS-GHA posts a comment listing them with per-slice messages
- Enables incremental migration of slices away from TACOS-GHA

## How it works

### Sentinel file

Drop a `.tacos-disabled` file in a slice directory (or any ancestor) to disable all slices under it. The file must be committed and tracked by git.

`PathFilter` gains an `is_disabled()` method that walks up the directory tree looking for `.tacos-disabled`. Two implementations: one checks the git file index (used in PR workflows where we already have the file list), the other checks disk (used in the drift detection pipe filter).

### Unlock bypass

The unlock workflow sets `TACOS_IGNORE_DISABLED=1` so that disabled slices still get their locks released when a PR is closed or converted to draft. `match()` only checks the allowlist — the disabled check is the caller's responsibility, keeping the two concerns cleanly separated.

### PR notification

When a PR touches disabled slices, the `list-slices` action collects them (with messages) into a `disabled_slices` output. A new `notify-disabled-slices` composite action renders a PR comment listing each disabled slice and its message. The comment is removed automatically when no disabled slices remain.

Custom messages come from the `.tacos-disabled` file content; an empty file uses a default message.

The notification step uses `continue-on-error: true` so a comment API failure never blocks planning.

## Usage

Disable all slices under a subtree:
```bash
touch terragrunt/regions/multi-tenant/kafka/.tacos-disabled
git add terragrunt/regions/multi-tenant/kafka/.tacos-disabled
```

Disable a single slice with a custom message:
```bash
echo "This slice is now managed externally." > path/to/slice/.tacos-disabled
git add path/to/slice/.tacos-disabled
```

## Changes

- `lib/tacos/path_filter.py` — `is_disabled()`, `_is_disabled_from_disk()`, `_is_disabled_from_fs()`, `disabled_message()` methods
- `lib/tacos/dependent_slices.py` — disabled slice collection via `TACOS_DISABLED_FILE` env var, `TACOS_IGNORE_DISABLED` bypass
- `lib/ci/list-slices` — captures disabled slices JSON and sets `disabled_slices` output
- `.github/actions/list-slices/action.yml` — new `disabled_slices` output
- `.github/actions/notify-disabled-slices/action.yml` — new composite action for PR comments
- `.github/workflows/tacos_plan.yml` — calls notify-disabled-slices after list-slices
- `.github/workflows/tacos_unlock.yml` — sets `TACOS_IGNORE_DISABLED=1`
- `doc/USER_GUIDE.md` — documents the sentinel file mechanism

## Test plan

- [x] `path_filter_test.py`: 12 tests covering sentinel in slice dir, parent dir, sibling isolation, allowlist interaction, disk-based checks, custom/default/parent messages
- [x] `dependent_slices_test.py`: 2 tests confirming sentinel categorization behavior
- [x] All tests pass

