### PR TITLE
Merge main into stable

### DIFF
--- a/.github/actions/list-slices/action.yml
+++ b/.github/actions/list-slices/action.yml
@@ -9,6 +9,9 @@ outputs:
   slices:
     description: "JSON list of paths to relevant TF/TG slices"
     value: ${{ steps.list-slices.outputs.slices }}
+  disabled_slices:
+    description: "JSON list of disabled slices with messages"
+    value: ${{ steps.list-slices.outputs.disabled_slices }}
 
 runs:
   using: composite

--- a/.github/actions/notify-disabled-slices/action.yml
+++ b/.github/actions/notify-disabled-slices/action.yml
@@ -1,0 +1,51 @@
+name: Notify Disabled Slices
+
+inputs:
+  disabled_slices:
+    description: "JSON list of disabled slices from list-slices action"
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Render Comment
+      id: render
+      if: inputs.disabled_slices != '[]'
+      shell: bash
+      env:
+        DISABLED_SLICES: ${{ inputs.disabled_slices }}
+      run: |
+        comment="### ⚠️ Disabled Slices"
+        comment+=$'\n\n'
+        comment+="The following slices in this PR are **disabled** in TACOS-GHA and will not be planned or applied:"
+        comment+=$'\n\n'
+
+        while IFS= read -r line; do
+          slice="$(echo "$line" | jq -r '.slice')"
+          message="$(echo "$line" | jq -r '.message')"
+          comment+="- \`${slice}\` — ${message}"
+          comment+=$'\n'
+        done < <(echo "$DISABLED_SLICES" | jq -c '.[]')
+
+        delimiter="TACOS_$(openssl rand -hex 8)"
+        {
+          echo "comment<<${delimiter}"
+          echo "$comment"
+          echo "${delimiter}"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Post Disabled Slices Comment
+      if: inputs.disabled_slices != '[]'
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        comment-tag: tacos-disabled
+        mode: recreate
+        message: ${{ steps.render.outputs.comment }}
+
+    - name: Remove Stale Disabled Slices Comment
+      if: inputs.disabled_slices == '[]'
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+      with:
+        comment-tag: tacos-disabled
+        mode: delete

--- a/.github/workflows/tacos_apply.yml
+++ b/.github/workflows/tacos_apply.yml
@@ -17,6 +17,12 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      DD_API_KEY:
+        description: "Datadog API key for Terraform provider"
+        required: false
+      DD_APP_KEY:
+        description: "Datadog App key for Terraform provider"
+        required: false
 
 defaults:
   run:
@@ -83,6 +89,8 @@ jobs:
 
     env:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
     steps:
       - name: Checkout IAC
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/tacos_detect_drift.yml
+++ b/.github/workflows/tacos_detect_drift.yml
@@ -17,6 +17,12 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      DD_API_KEY:
+        description: "Datadog API key for Terraform provider"
+        required: false
+      DD_APP_KEY:
+        description: "Datadog App key for Terraform provider"
+        required: false
 
 defaults:
   run:
@@ -72,6 +78,8 @@ jobs:
 
     env:
       TF_ROOT_MODULES: ${{needs.determine-tf-root-modules.outputs.slices}}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
     steps:
       - name: Checkout IAC
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -71,6 +71,12 @@ jobs:
         id: list-slices
         uses: ./tacos-gha/.github/actions/list-slices
 
+      - name: Notify Disabled Slices
+        continue-on-error: true
+        uses: ./tacos-gha/.github/actions/notify-disabled-slices
+        with:
+          disabled_slices: ${{ steps.list-slices.outputs.disabled_slices }}
+
   tacos_plan:
     name: TACOS Plan
     needs: [determine-tf-root-modules]

--- a/.github/workflows/tacos_plan.yml
+++ b/.github/workflows/tacos_plan.yml
@@ -20,6 +20,12 @@ on:
       ssh-private-key:
         description: "Private SSH key to use for git clone"
         required: false
+      DD_API_KEY:
+        description: "Datadog API key for Terraform provider"
+        required: false
+      DD_APP_KEY:
+        description: "Datadog App key for Terraform provider"
+        required: false
 
 defaults:
   run:
@@ -86,6 +92,8 @@ jobs:
 
     env:
       TF_ROOT_MODULE: ${{matrix.tf-root-module}}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
     steps:
       - name: Checkout IAC
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/tacos_unlock.yml
+++ b/.github/workflows/tacos_unlock.yml
@@ -42,6 +42,9 @@ jobs:
       contents: read
       pull-requests: write
 
+    env:
+      TACOS_IGNORE_DISABLED: "1"
+
     steps:
       - name: Checkout IAC
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -35,6 +35,41 @@ These allowlists can consist of empty lines, comments where the first character
 of the line is a #, and patterns that will be matched to slices with with
 python's [fnmatch module](https://docs.python.org/3/library/fnmatch.html).
 
+## Disabling TACOS-GHA for a slice
+
+To disable TACOS-GHA for a specific slice or subtree, create an empty
+`.tacos-disabled` sentinel file in the target directory. TACOS-GHA will skip
+any slice that contains a `.tacos-disabled` file in its directory or any
+ancestor directory. This is useful for incrementally retiring slices from
+TACOS-GHA management.
+
+For example, to disable all slices under `terragrunt/regions/multi-tenant/kafka/`:
+
+```
+touch terragrunt/regions/multi-tenant/kafka/.tacos-disabled
+git add terragrunt/regions/multi-tenant/kafka/.tacos-disabled
+```
+
+To disable a single slice:
+
+```
+touch terragrunt/regions/multi-tenant/kafka/snuba-errors/us/.tacos-disabled
+git add terragrunt/regions/multi-tenant/kafka/snuba-errors/us/.tacos-disabled
+```
+
+The sentinel file must be committed and tracked by git to take effect. The
+unlock workflow ignores the sentinel so that locks on disabled slices are
+still released when a pull request is closed or converted to draft.
+
+If a PR touches disabled slices, TACOS-GHA will post a comment listing them.
+To customize the message, write it into the `.tacos-disabled` file:
+
+```
+echo "This slice is now managed externally." > terragrunt/regions/multi-tenant/kafka/.tacos-disabled
+```
+
+An empty file uses a default message.
+
 # Usage
 
 ## The Pull Request

--- a/lib/ci/list-slices
+++ b/lib/ci/list-slices
@@ -2,6 +2,9 @@
 # stdin: json listing of all files editted
 set -euo pipefail
 
+export TACOS_DISABLED_FILE
+TACOS_DISABLED_FILE="$(mktemp)"
+
 jq '.[]' --raw-output |
   python3.12 -P -m lib.tacos.dependent_slices |
   # transform newline-delimited list into json:
@@ -12,3 +15,12 @@ jq '.[]' --raw-output |
   # prettify
   jq . \
 ;
+
+if [ -s "$TACOS_DISABLED_FILE" ]; then
+  jq -c '.' "$TACOS_DISABLED_FILE" |
+    gha-set-output disabled_slices
+else
+  echo '[]' | gha-set-output disabled_slices
+fi
+
+rm -f "$TACOS_DISABLED_FILE"

--- a/lib/tacos/apply
+++ b/lib/tacos/apply
@@ -8,7 +8,7 @@ exec 3>&1 1>&2
   sudo-gcp tf-lock-acquire
 )
 
-if [ "${TERRAGRUNT_VERSION}" = "0.54.15" ]; then
+if [[ "${TERRAGRUNT_VERSION}" == 0.* ]]; then
     run_all=("run-all")
 else
     run_all=("run" "--all" "--")

--- a/lib/tacos/dependent_slices.py
+++ b/lib/tacos/dependent_slices.py
@@ -244,17 +244,34 @@ def lines_to_paths(lines: Iterable[str]) -> Generator[OSPath]:
 
 def main() -> int:
     import fileinput
+    import json
+    import os
+    import sys
 
     fs = FileSystem.from_git()
     modified_paths = lines_to_paths(fileinput.input(encoding="utf-8"))
 
     path_filter = PathFilter.from_config()
+    ignore_disabled = bool(os.environ.get("TACOS_IGNORE_DISABLED"))
+
+    disabled: list[dict[str, str]] = []
 
     for slice in dependent_slices(modified_paths, fs):
-        if path_filter.match(str(slice)):
+        if not ignore_disabled and path_filter.is_disabled(str(slice), fs.files):
+            sh.debug(f"slice disabled by .tacos-disabled: {slice}")
+            disabled.append({
+                "slice": str(slice),
+                "message": path_filter.disabled_message(str(slice)),
+            })
+        elif path_filter.match(str(slice)):
             print(slice)
         else:
             sh.debug(f"slice ignored due to allowlist: {slice}")
+
+    disabled_file = os.environ.get("TACOS_DISABLED_FILE")
+    if disabled_file:
+        with open(disabled_file, "w") as f:
+            json.dump(disabled, f)
 
     return 0
 

--- a/lib/tacos/dependent_slices_test.py
+++ b/lib/tacos/dependent_slices_test.py
@@ -166,6 +166,35 @@ class TestDependentSlices:
         )
 
 
+class TestDisabledSentinel:
+    def test_disabled_slice_still_in_categorized(self) -> None:
+        """TFCategorized sees all slices; .tacos-disabled filtering is separate."""
+        paths = (
+            OSPath("terraform/slice-0/main.tf"),
+            OSPath("terraform/slice-0/.tacos-disabled"),
+            OSPath("terraform/slice-1/main.tf"),
+        )
+        fs = D.FileSystem.from_paths(paths)
+        categorized = D.TFCategorized.from_fs(fs)
+        assert categorized.slices == frozenset({
+            D.TopLevelTFModule(D.TFModule(D.Dir(Path("terraform/slice-0")))),
+            D.TopLevelTFModule(D.TFModule(D.Dir(Path("terraform/slice-1")))),
+        })
+
+    def test_sentinel_does_not_affect_categorization(self) -> None:
+        """The sentinel is a filter, not a categorization concern.
+        TFCategorized still sees disabled slices; filtering happens later."""
+        paths = (
+            OSPath("env/prod/slice-0/thing.tf"),
+            OSPath("env/prod/slice-0/.tacos-disabled"),
+        )
+        fs = D.FileSystem.from_paths(paths)
+        categorized = D.TFCategorized.from_fs(fs)
+        assert D.TopLevelTFModule(
+            D.TFModule(D.Dir(Path("env/prod/slice-0")))
+        ) in categorized.slices
+
+
 class TestRegressions:
     """Real-world cases that (initially) weren't caught by unit-tests."""
 

--- a/lib/tacos/path_filter.py
+++ b/lib/tacos/path_filter.py
@@ -5,8 +5,10 @@ from dataclasses import dataclass
 from fnmatch import fnmatch
 
 from lib.types import OSPath
+from lib.types import Path
 
 CONFIG_PATH = OSPath(".config/tacos-gha/slices.allowlist")
+DISABLED_SENTINEL = ".tacos-disabled"
 
 
 @dataclass(frozen=True)
@@ -14,6 +16,41 @@ class PathFilter:
     """A frozen view of a collection of files."""
 
     allowed: frozenset[str]
+    disabled_sentinel: str = DISABLED_SENTINEL
+
+    def is_disabled(self, path: str, fs_files: frozenset[Path] | None = None) -> bool:
+        """Check if a slice is disabled by a sentinel file in it or any ancestor."""
+        if fs_files is not None:
+            return self._is_disabled_from_fs(path, fs_files)
+        return self._is_disabled_from_disk(path)
+
+    def _is_disabled_from_disk(self, path: str) -> bool:
+        p = OSPath(path)
+        for ancestor in (p, *p.parents):
+            sentinel = ancestor / self.disabled_sentinel
+            if sentinel.is_file() and not sentinel.is_symlink():
+                return True
+        return False
+
+    def _is_disabled_from_fs(self, path: str, fs_files: frozenset[Path]) -> bool:
+        p = Path(path)
+        for ancestor in (p, *p.parents):
+            sentinel = Path(str(ancestor / self.disabled_sentinel))
+            if sentinel in fs_files and not OSPath(sentinel).is_symlink():
+                return True
+        return False
+
+    def disabled_message(self, path: str) -> str:
+        """Read the content of the nearest .tacos-disabled sentinel file."""
+        p = OSPath(path)
+        for ancestor in (p, *p.parents):
+            sentinel = ancestor / self.disabled_sentinel
+            if sentinel.is_file() and not sentinel.is_symlink():
+                content = sentinel.read_text().strip()
+                if content:
+                    return content
+                break
+        return "This slice has been disabled in TACOS-GHA."
 
     def match(self, path: str) -> bool:
         if not self.allowed:
@@ -47,6 +84,8 @@ class PathFilter:
 def main() -> int:
     import fileinput
 
+    from lib.sh import sh
+
     path_filter = PathFilter.from_config()
 
     for line in fileinput.input(encoding="utf-8"):
@@ -54,7 +93,9 @@ def main() -> int:
         if not line or line.startswith("#"):
             continue
 
-        if path_filter.match(line):
+        if path_filter.is_disabled(line):
+            sh.debug(f"slice disabled by {DISABLED_SENTINEL}: {line}")
+        elif path_filter.match(line):
             print(line)
 
     return 0

--- a/lib/tacos/path_filter_test.py
+++ b/lib/tacos/path_filter_test.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from lib.types import OSPath
+from lib.types import Path
+
+from .path_filter import PathFilter
+
+
+class TestPathFilterDisabled:
+    def test_not_disabled_by_default(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+        })
+        assert not pf.is_disabled("terraform/slice-0", fs_files)
+
+    def test_disabled_by_sentinel_in_slice(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+            Path("terraform/slice-0/.tacos-disabled"),
+        })
+        assert pf.is_disabled("terraform/slice-0", fs_files)
+
+    def test_disabled_by_sentinel_in_parent(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+            Path("terraform/.tacos-disabled"),
+        })
+        assert pf.is_disabled("terraform/slice-0", fs_files)
+
+    def test_disabled_does_not_affect_sibling(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        fs_files: frozenset[Path] = frozenset({
+            Path("terraform/slice-0/main.tf"),
+            Path("terraform/slice-0/.tacos-disabled"),
+            Path("terraform/slice-1/main.tf"),
+        })
+        assert pf.is_disabled("terraform/slice-0", fs_files)
+        assert not pf.is_disabled("terraform/slice-1", fs_files)
+
+    def test_match_ignores_disabled(self) -> None:
+        """match() only checks the allowlist; disabled filtering is the caller's job."""
+        pf = PathFilter(allowed=frozenset({"terraform/*"}))
+        assert pf.match("terraform/slice-0")
+
+    def test_disabled_at_disk(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        (slice_dir / ".tacos-disabled").touch()
+        assert pf._is_disabled_from_disk(str(slice_dir))
+
+    def test_not_disabled_at_disk(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        assert not pf._is_disabled_from_disk(str(slice_dir))
+
+    def test_disabled_message_custom(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        (slice_dir / ".tacos-disabled").write_text("Managed by Spacelift now.")
+        assert pf.disabled_message(str(slice_dir)) == "Managed by Spacelift now."
+
+    def test_disabled_message_default(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        (slice_dir / ".tacos-disabled").touch()
+        assert pf.disabled_message(str(slice_dir)) == "This slice has been disabled in TACOS-GHA."
+
+    def test_disabled_message_from_parent(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        parent = tmp_path / "terraform"
+        parent.mkdir(parents=True)
+        (parent / ".tacos-disabled").write_text("Entire subtree migrated.")
+        slice_dir = parent / "slice-0"
+        slice_dir.mkdir()
+        assert pf.disabled_message(str(slice_dir)) == "Entire subtree migrated."
+
+    def test_symlink_sentinel_ignored_on_disk(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        target = tmp_path / "secret"
+        target.write_text("token=s3cret")
+        (slice_dir / ".tacos-disabled").symlink_to(target)
+        assert not pf._is_disabled_from_disk(str(slice_dir))
+
+    def test_symlink_sentinel_ignored_from_fs(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        target = tmp_path / "secret"
+        target.write_text("token=s3cret")
+        (slice_dir / ".tacos-disabled").symlink_to(target)
+        fs_files: frozenset[Path] = frozenset({
+            Path(str(slice_dir / "main.tf")),
+            Path(str(slice_dir / ".tacos-disabled")),
+        })
+        assert not pf.is_disabled(str(slice_dir), fs_files)
+
+    def test_symlink_sentinel_message_returns_default(self, tmp_path: OSPath) -> None:
+        pf = PathFilter(allowed=frozenset())
+        slice_dir = tmp_path / "terraform" / "slice-0"
+        slice_dir.mkdir(parents=True)
+        target = tmp_path / "secret"
+        target.write_text("token=s3cret")
+        (slice_dir / ".tacos-disabled").symlink_to(target)
+        assert pf.disabled_message(str(slice_dir)) == "This slice has been disabled in TACOS-GHA."
+
+
+class TestPathFilterAllowlist:
+    def test_empty_allows_all(self) -> None:
+        pf = PathFilter(allowed=frozenset())
+        assert pf.match("anything/at/all")
+
+    def test_pattern_match(self) -> None:
+        pf = PathFilter(allowed=frozenset({"terraform/*"}))
+        assert pf.match("terraform/slice-0")
+        assert not pf.match("other/slice-0")

--- a/lib/tacos/plan
+++ b/lib/tacos/plan
@@ -7,7 +7,7 @@ exec 3>&1 1>&2
 # note: for terragrunt, tfplan must be absolute
 TACOS_TFPLAN="${TACOS_TFPLAN:-$PWD/tfplan}"
 TACOS_LOCK="${TACOS_LOCK:-false}"
-if [ "${TERRAGRUNT_VERSION}" = "0.54.15" ]; then
+if [[ "${TERRAGRUNT_VERSION}" == 0.* ]]; then
     run_all=("run-all")
 else
     run_all=("run" "--all" "--")

--- a/lib/tf_lock/lib/env.py
+++ b/lib/tf_lock/lib/env.py
@@ -51,7 +51,7 @@ path_prepend("PATH", TACOS_GHA_HOME + "/lib/tf_lock/bin")
 def tf_working_dir(root_module: OSPath) -> Path:
     if (root_module / "terragrunt.hcl").exists():
         with sh.cd(root_module):
-            if TERRAGRUNT_VERSION == "0.54.15":
+            if TERRAGRUNT_VERSION.startswith("0."):
                 working_dir_key = "WorkingDir"
                 # validate-inputs makes terragrunt generate its templates
                 sh.run((

--- a/lib/tf_lock/lib/env.sh
+++ b/lib/tf_lock/lib/env.sh
@@ -18,7 +18,7 @@ tf_working_dir() {
   root_module="$1"
   if [[ -e "$root_module/terragrunt.hcl" ]]; then
     ( cd "$root_module"
-      if [ "${TERRAGRUNT_VERSION}" = "0.54.15" ]; then
+      if [[ "${TERRAGRUNT_VERSION}" == 0.* ]]; then
         # validate-inputs makes terragrunt generate its templates
         terragrunt --terragrunt-no-auto-init=false validate-inputs
 

--- a/lib/tf_lock/release.py
+++ b/lib/tf_lock/release.py
@@ -164,7 +164,7 @@ def tf_working_dir(root_module: Path) -> Path:
 
     if OSPath(root_module / "terragrunt.hcl").exists():
         with sh.cd(root_module):
-            if TERRAGRUNT_VERSION == "0.54.15":
+            if TERRAGRUNT_VERSION.startswith("0."):
                 working_dir_key = "WorkingDir"
                 sh.run(("terragrunt", "validate-inputs"))
                 info = sh.json(("terragrunt", "terragrunt-info"))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 astroid==3.2.4
     # via pylint
-black==24.4.2
+black==26.3.1
     # via -r requirements-dev.in
 build==1.2.1
     # via pip-tools
@@ -67,7 +67,7 @@ packaging==24.1
     #   pytest
 parso==0.8.4
     # via jedi
-pathspec==0.12.1
+pathspec==1.0.4
     # via black
 pip-tools==7.4.1
     # via -r requirements-dev.in
@@ -102,6 +102,8 @@ pytest==8.3.1
     #   pytest-xdist
 pytest-xdist==3.6.1
     # via -r requirements-dev.in
+pytokens==0.4.1
+    # via black
 pyyaml==6.0.1
     # via pre-commit
 tomlkit==0.13.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -65,6 +65,7 @@ packaging==24.1
     #   build
     #   pudb
     #   pytest
+    #   wheel
 parso==0.8.4
     # via jedi
 pathspec==1.0.4
@@ -124,7 +125,7 @@ virtualenv==20.36.1
     #   pre-commit
 wcwidth==0.2.13
     # via urwid
-wheel==0.43.0
+wheel==0.46.2
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,7 @@ distlib==0.3.8
     # via virtualenv
 execnet==2.1.1
     # via pytest-xdist
-filelock==3.15.4
+filelock==3.25.2
     # via virtualenv
 identify==2.6.0
     # via pre-commit
@@ -118,7 +118,7 @@ urwid==2.6.15
     #   urwid-readline
 urwid-readline==0.14
     # via pudb
-virtualenv==20.35.4
+virtualenv==20.36.1
     # via
     #   -r requirements-dev.in
     #   pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ black==26.3.1
     # via -r requirements-dev.in
 build==1.2.1
     # via pip-tools
-cffi==1.16.0
+cffi==2.1.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
@@ -27,7 +27,7 @@ coverage==7.6.0
     #   coverage-enable-subprocess
 coverage-enable-subprocess==1.0
     # via -r requirements-dev.in
-cryptography==43.0.0
+cryptography==48.0.1
     # via pyjwt
 dill==0.3.8
     # via pylint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -85,7 +85,7 @@ pudb==2024.1.2
     # via -r requirements-dev.in
 pycparser==2.22
     # via cffi
-pygments==2.18.0
+pygments==2.20.0
     # via pudb
 pyjwt==2.8.0
     # via -r requirements-dev.in

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -87,8 +87,10 @@ pycparser==2.22
     # via cffi
 pygments==2.20.0
     # via pudb
-pyjwt==2.8.0
-    # via -r requirements-dev.in
+pyjwt==2.13.0
+    # via
+    #   -r requirements-dev.in
+    #   pyjwt
 pylint==3.2.6
     # via -r requirements-dev.in
 pyproject-hooks==1.1.0


### PR DESCRIPTION
## Summary

Merge `main` into `stable` to release the following changes:

### Bug fixes
- **fix: use version prefix match for Terragrunt 0.x** (#309) — The exact-match check against `0.54.15` caused all other 0.x versions (e.g. 0.57.2) to incorrectly use TG 1.x commands, failing with "Terraform has no command named hcl"

### Features
- **feat: add Datadog secret inputs to reusable workflows** (#313) — Adds `DD_API_KEY` and `DD_APP_KEY` as optional secret inputs to `tacos_plan`, `tacos_apply`, and `tacos_detect_drift` reusable workflows
- **Add .tacos-disabled sentinel file to skip slices** (#315) — Drop a `.tacos-disabled` file in a slice directory or ancestor to disable it from TACOS-GHA management (plan, apply, drift detection). Includes PR comment notifications for disabled slices, unlock bypass, and symlink protection

### Dependency updates
- Bump black from 24.4.2 to 26.3.1 (#293)
- Bump virtualenv from 20.35.4 to 20.36.1 (#292)
- Bump wheel from 0.43.0 to 0.46.2 (#296)
- Bump pygments from 2.18.0 to 2.20.0 (#300)
- Bump pyjwt from 2.8.0 to 2.13.0 (#310)
- Bump cryptography from 43.0.0 to 48.0.1 (#314)
