### PR TITLE
Fix dependent slice planning when a slice is emptied

### DIFF
--- a/lib/tacos/dependent_slices.py
+++ b/lib/tacos/dependent_slices.py
@@ -185,14 +185,17 @@ class TFCategorized:
 
     def config_deps(self) -> SliceDeps:
         """Map from config dirs to the slices that (could) depend on them."""
-        config_deps: dict[TFConfigDir, set[TopLevelTFModule]] = {}
-        for config_dir in self.config_dirs:
-            config_deps[config_dir] = set()
-            for slice in self.slices:
-                if dir_contains(config_dir, slice):
-                    config_deps[config_dir].add(slice)
+        return {
+            config_dir: self.slices_depending_on(config_dir)
+            for config_dir in self.config_dirs
+        }
 
-        return {var: frozenset(val) for var, val in config_deps.items()}
+    def slices_depending_on(
+        self, config_dir: TFConfigDir
+    ) -> frozenset[TopLevelTFModule]:
+        return frozenset(
+            slice for slice in self.slices if dir_contains(config_dir, slice)
+        )
 
     @property
     def config_dirs(self) -> frozenset[TFConfigDir]:
@@ -229,9 +232,8 @@ def dependent_slices(
     # do we need to worry about indirect modifications?
     if modified.shared_dirs or modified.config_files:
         all = TFCategorized.from_fs(fs)
-        config_deps = all.config_deps()
         for config_dir in modified.config_dirs:
-            yield from sorted(config_deps[config_dir])
+            yield from sorted(all.slices_depending_on(config_dir))
 
 
 def lines_to_paths(lines: Iterable[str]) -> Generator[OSPath]:
@@ -257,7 +259,9 @@ def main() -> int:
     disabled: list[dict[str, str]] = []
 
     for slice in dependent_slices(modified_paths, fs):
-        if not ignore_disabled and path_filter.is_disabled(str(slice), fs.files):
+        if not ignore_disabled and path_filter.is_disabled(
+            str(slice), fs.files
+        ):
             sh.debug(f"slice disabled by .tacos-disabled: {slice}")
             disabled.append({
                 "slice": str(slice),

--- a/lib/tacos/dependent_slices_test.py
+++ b/lib/tacos/dependent_slices_test.py
@@ -190,13 +190,31 @@ class TestDisabledSentinel:
         )
         fs = D.FileSystem.from_paths(paths)
         categorized = D.TFCategorized.from_fs(fs)
-        assert D.TopLevelTFModule(
-            D.TFModule(D.Dir(Path("env/prod/slice-0")))
-        ) in categorized.slices
+        assert (
+            D.TopLevelTFModule(D.TFModule(D.Dir(Path("env/prod/slice-0"))))
+            in categorized.slices
+        )
 
 
 class TestRegressions:
     """Real-world cases that (initially) weren't caught by unit-tests."""
+
+    def test_emptied_slice(self) -> None:
+        fs = D.FileSystem.from_paths((
+            OSPath("env/prod/removed/README.md"),
+            OSPath("env/prod/remaining/main.tf"),
+        ))
+        modified = (OSPath("env/prod/removed/main.tf"),)
+
+        assert tuple(D.dependent_slices(modified, fs)) == ()
+
+    def test_deleted_config_still_plans_descendants(self) -> None:
+        fs = D.FileSystem.from_paths((OSPath("env/prod/slice-0/main.tf"),))
+        modified = (OSPath("env/prod/terragrunt.hcl"),)
+
+        assert tuple(D.dependent_slices(modified, fs)) == (
+            D.TopLevelTFModule(D.TFModule(D.Dir(Path("env/prod/slice-0")))),
+        )
 
     def test_root_is_slice(self) -> None:
         modified = {


### PR DESCRIPTION
## Summary

- resolve dependent slices directly from the current slice set for any modified config directory
- avoid a `KeyError` when a slice has been emptied and no longer appears in the current config dependency map
- continue planning surviving descendants when an inherited config file is deleted
- add regressions for both deletion paths

Fixes #273.

## Root cause

`dependent_slices()` indexed a dependency map built only from config directories that still exist in the current filesystem. A deleted Terraform config is present in the modified path set but absent from that map, so direct indexing raised `KeyError`.

Computing descendants for the modified directory itself handles both cases: an emptied slice has no current descendants, while removal of a shared config still returns the slices below it.

## Validation

- all 14 tests in `lib/tacos/dependent_slices_test.py` passed under WSL Python 3.12, including the temporary-directory Git test
- `python3 -m compileall -q lib/tacos/dependent_slices.py lib/tacos/dependent_slices_test.py`
- `black==26.3.1 --check`
- `isort==5.13.2 --check-only`
- `mypy==1.11.0`
- `git diff --check`

Pyright reaches the changed modules but reports the pre-existing unused `sys` import at `lib/tacos/dependent_slices.py:251`, outside this diff.
