### PR TITLE
Fix TACOS OpenTofu compatibility issues

### DIFF
--- a/lib/ci/bin/terragrunt-noninteractive
+++ b/lib/ci/bin/terragrunt-noninteractive
@@ -23,7 +23,7 @@ export TERRAGRUNT_NO_AUTO_APPROVE=true
 # * we use tf-lock-acquire to take the lock, before terragrunt starts
 # * we run `terraform refresh` separately, in ci-tf-init
 export TF_CLI_ARGS=""
-export TF_CLI_ARGS_init="-lock=false -upgrade"
+export TF_CLI_ARGS_init="-lock=false -upgrade -reconfigure"
 export TF_CLI_ARGS_refresh="-lock=false -refresh=false"
 export TF_CLI_ARGS_plan="-lock=false -refresh=false -detailed-exitcode"
 export TF_CLI_ARGS_apply="-lock=false -refresh=false"

--- a/lib/ci/bin/terragrunt-noninteractive
+++ b/lib/ci/bin/terragrunt-noninteractive
@@ -23,7 +23,7 @@ export TERRAGRUNT_NO_AUTO_APPROVE=true
 # * we use tf-lock-acquire to take the lock, before terragrunt starts
 # * we run `terraform refresh` separately, in ci-tf-init
 export TF_CLI_ARGS=""
-export TF_CLI_ARGS_init="-lock=false"
+export TF_CLI_ARGS_init="-lock=false -upgrade"
 export TF_CLI_ARGS_refresh="-lock=false -refresh=false"
 export TF_CLI_ARGS_plan="-lock=false -refresh=false -detailed-exitcode"
 export TF_CLI_ARGS_apply="-lock=false -refresh=false"

--- a/lib/ci/tacos_summary.py
+++ b/lib/ci/tacos_summary.py
@@ -161,7 +161,7 @@ class SliceSummary(NamedTuple):
     def applied(self) -> bool:
         """The job succeeded and made changes."""
         if self.tacos_verb == "apply" and self._in_any_log_line(
-            "Terraform will perform the following actions:"
+            "will perform the following actions:"
         ):
             return self.returncode == 0
         else:

--- a/lib/tf_lock/lib/acquire.py
+++ b/lib/tf_lock/lib/acquire.py
@@ -24,7 +24,8 @@ echo line: "$line"
     )
 else:
     TIMEOUT = 1 * TF_SLEEP + 1
-TERRAFORM = ("terraform", "console")
+    _tf_bin = getenv("TERRAFORM_BINARY") or "tofu"
+    TERRAFORM: Command = (_tf_bin, "console")
 
 
 def debug(*msg: object) -> None:

--- a/lib/tf_lock/release.py
+++ b/lib/tf_lock/release.py
@@ -16,6 +16,7 @@ from lib.types import Path
 from lib.user_error import UserError
 
 HERE = sh.get_HERE(__file__)
+_TF_BIN = environ.get("TERRAFORM_BINARY") or "tofu"
 TF_LOCK_EHELD = 3
 TERRAGRUNT_VERSION = environ["TERRAGRUNT_VERSION"]
 
@@ -135,7 +136,7 @@ def tf_lock_release(root_module: Path, env: Environ) -> None:
         try:
             with sh.cd(tf_working_dir(root_module)):
                 sh.run((
-                    "terraform",
+                    _TF_BIN,
                     "force-unlock",
                     "-force",
                     "--",

--- a/lib/tf_lock/tf-lock-info
+++ b/lib/tf_lock/tf-lock-info
@@ -37,11 +37,11 @@ while (( i < limit )); do
     echo '{"lock": false}'
     exit 0
   elif grep -Eq <<< "$error" \
-      'Error: .*(Backend initialization required, please run "terraform init"|Required plugins are not installed)'
+      'Error: .*(Backend initialization required|Required plugins are not installed)'
     then
     ( # NB: need to undo the cd to keep relative paths valid
       cd "$working_dir"
-      if ! noise="$("$TF" init 2>&1)" || (( i == limit )); then
+      if ! noise="$("$TF" init -reconfigure 2>&1)" || (( i == limit )); then
         echo >&2 Terraform init failed!
         echo >&2 "$noise"
         exit 1

--- a/lib/tf_lock/tf-lock-info
+++ b/lib/tf_lock/tf-lock-info
@@ -33,7 +33,7 @@ while (( i < limit )); do
     then
     echo >&2 "No remote tfstate configured, path: '$root_module'"
     exit 1
-  elif grep -Eq <<< "$error" $'storage: object doesn'\''t exist$'; then
+  elif grep -Eq <<< "$error" $'storage: object doesn'\''t exist'; then
     echo '{"lock": false}'
     exit 0
   elif grep -Eq <<< "$error" \

--- a/lib/tf_lock/tf-lock-info
+++ b/lib/tf_lock/tf-lock-info
@@ -3,6 +3,8 @@ set -eEuo pipefail
 HERE="$(dirname "$(readlink -f "$0")")"
 . "$HERE/"lib/env.sh
 
+TF="${TERRAFORM_BINARY:-$(command -v tofu >/dev/null 2>&1 && echo tofu || echo terraform)}"
+
 root_module="${1:-"$PWD"}"
 working_dir="$(tf_working_dir "$root_module")"
 
@@ -16,7 +18,7 @@ while (( i < limit )); do
   fancy_error="$(
     cd "$working_dir" || exit 1
     # swap stdout and stderr:
-    terraform force-unlock -force -- -1 3>&2 2>&1 1>&3 <<< ""
+    "$TF" force-unlock -force -- -1 3>&2 2>&1 1>&3 <<< ""
   )" && status=$? || status=$?
   # strip ansi fanciness from error messages, for automated consumption
   error="$(
@@ -39,7 +41,7 @@ while (( i < limit )); do
     then
     ( # NB: need to undo the cd to keep relative paths valid
       cd "$working_dir"
-      if ! noise="$(terraform init 2>&1)" || (( i == limit )); then
+      if ! noise="$("$TF" init 2>&1)" || (( i == limit )); then
         echo >&2 Terraform init failed!
         echo >&2 "$noise"
         exit 1

--- a/spec/behaviors/apply_on_update.py
+++ b/spec/behaviors/apply_on_update.py
@@ -62,7 +62,7 @@ tf-lock-acquire: success: .(""",  # the next bit is github-username@fake-pr-doma
 $ sudo-gcp terragrunt run-all init
 You are authenticated for the next hour as: tacos-gha-tf-apply@sac-dev-sa.iam.gserviceaccount.com
 """,
-                "\nTerraform has been successfully initialized!\n",
+                "\nhas been successfully initialized!\n",
                 "\n$ sudo-gcp terragrunt run-all refresh\n",
                 "\n$ sudo-gcp terragrunt run-all apply --auto-approve\n",
             ),
@@ -72,6 +72,6 @@ You are authenticated for the next hour as: tacos-gha-tf-apply@sac-dev-sa.iam.gs
         assert "tf-lock-release" not in commands
 
         tf_result: Parse = Parse(comment).between("</details>", "</details>")
-        assert "\nTerraform will perform the following actions:\n" in tf_result
+        assert "\nwill perform the following actions:\n" in tf_result
 
     pr.slices.assert_locked()

--- a/spec/behaviors/force_unlock_on_happy_path.py
+++ b/spec/behaviors/force_unlock_on_happy_path.py
@@ -22,7 +22,7 @@ def test(pr: tacos_demo.PR) -> None:
             == f"### TACOS Unlock: {pr.slices.subpath}/{slice}"
         )
 
-        assert "\nstate has been successfully unlocked!\n" in comment
+        assert "state has been successfully unlocked!\n" in comment
 
         assert "<summary>tf-lock-release: success: .(" in comment
         # the next bit is github-username@fake-pr-domain, which seems tricky

--- a/spec/behaviors/force_unlock_on_happy_path.py
+++ b/spec/behaviors/force_unlock_on_happy_path.py
@@ -22,7 +22,7 @@ def test(pr: tacos_demo.PR) -> None:
             == f"### TACOS Unlock: {pr.slices.subpath}/{slice}"
         )
 
-        assert "\nTerraform state has been successfully unlocked!\n" in comment
+        assert "\nstate has been successfully unlocked!\n" in comment
 
         assert "<summary>tf-lock-release: success: .(" in comment
         # the next bit is github-username@fake-pr-domain, which seems tricky

--- a/spec/behaviors/plan_on_push.py
+++ b/spec/behaviors/plan_on_push.py
@@ -80,7 +80,7 @@ You are authenticated for the next hour as: tacos-gha-tf-state-admin@sac-dev-sa.
         assert "tf-lock-release" not in commands
 
         tf_result: Parse = Parse(comment).between("</details>", "</details>")
-        assert "\nwill perform the following actions:\n" in tf_result
+        assert "will perform the following actions:\n" in tf_result
 
         assert (
             'apply "tfplan"\n```' in tf_result

--- a/spec/behaviors/plan_on_push.py
+++ b/spec/behaviors/plan_on_push.py
@@ -70,7 +70,7 @@ tf-lock-acquire: success: .(""",  # the next bit is github-username@fake-pr-doma
 $ sudo-gcp terragrunt run-all init
 You are authenticated for the next hour as: tacos-gha-tf-state-admin@sac-dev-sa.iam.gserviceaccount.com
 """,
-                "\nhas been successfully initialized!\n",
+                "has been successfully initialized!\n",
                 "\n$ sudo-gcp terragrunt run-all refresh\n",
                 "\n$ sudo-gcp terragrunt run-all plan -out $slice/tfplan\n",
             ),

--- a/spec/behaviors/plan_on_push.py
+++ b/spec/behaviors/plan_on_push.py
@@ -70,7 +70,7 @@ tf-lock-acquire: success: .(""",  # the next bit is github-username@fake-pr-doma
 $ sudo-gcp terragrunt run-all init
 You are authenticated for the next hour as: tacos-gha-tf-state-admin@sac-dev-sa.iam.gserviceaccount.com
 """,
-                "\nTerraform has been successfully initialized!\n",
+                "\nhas been successfully initialized!\n",
                 "\n$ sudo-gcp terragrunt run-all refresh\n",
                 "\n$ sudo-gcp terragrunt run-all plan -out $slice/tfplan\n",
             ),
@@ -80,16 +80,11 @@ You are authenticated for the next hour as: tacos-gha-tf-state-admin@sac-dev-sa.
         assert "tf-lock-release" not in commands
 
         tf_result: Parse = Parse(comment).between("</details>", "</details>")
-        assert "\nTerraform will perform the following actions:\n" in tf_result
+        assert "\nwill perform the following actions:\n" in tf_result
 
-        assert tf_result.strip().endswith(
-            """\
-Saved the plan to:
-tfplan
-
-To perform exactly these actions, run the following command to apply:
-    terraform apply "tfplan"
-```"""
+        assert (
+            'apply "tfplan"\n```' in tf_result
+            and "Saved the plan to:\ntfplan" in tf_result
         )
 
     # lock should continue to be held


### PR DESCRIPTION
## Summary

After [ops PR #22241](https://github.com/getsentry/ops/pull/22241) switched from Terraform to OpenTofu (`terraform_binary = "tofu"` in `root.hcl`), TACOS plan/apply broke in several ways. This PR fixes all identified OpenTofu compatibility issues in tacos-gha.

Discovered while debugging [ops PR #22256](https://github.com/getsentry/ops/pull/22256) (a one-line `shard_count` change) where plan succeeded but apply failed.

## Root Cause

Multiple places in tacos-gha hardcoded `terraform` as the binary name or matched against Terraform-specific output strings that OpenTofu changed (e.g. `"Terraform will perform..."` → `"OpenTofu will perform..."`).

## Changes

### Binary selection (use `tofu` instead of hardcoded `terraform`)

- **`lib/tf_lock/tf-lock-info`**: Added `TF` variable using `TERRAFORM_BINARY` env var, defaulting to `tofu`. Replaced hardcoded `terraform` in `force-unlock` and fallback `init` calls.
- **`lib/tf_lock/lib/acquire.py`**: Lock acquisition now uses `TERRAFORM_BINARY` env var (default `tofu`) instead of hardcoded `"terraform"` for `console` command.
- **`lib/tf_lock/release.py`**: Lock release `force-unlock` now uses `TERRAFORM_BINARY` env var (default `tofu`).

### Init flags for CI

- **`lib/ci/bin/terragrunt-noninteractive`**: Changed `TF_CLI_ARGS_init` from `"-lock=false"` to `"-lock=false -upgrade -reconfigure"`.
  - `-upgrade`: re-resolves providers from constraints instead of trusting stale lock files created by auto-init during `tf-lock-acquire`
  - `-reconfigure`: required for non-interactive backend initialization with `-upgrade`

### Error pattern matching in `tf-lock-info`

- **Backend init error**: Pattern expected `"terraform init"` in the error message but tofu says `"tofu init"`. Simplified to match `"Backend initialization required"` without the binary name.
- **Missing state object**: Pattern used `$` end-of-line anchor but tofu's error includes additional googleapi details after `"object doesn't exist"`. Removed the anchor.
- **Fallback init**: Added `-reconfigure` to the fallback `$TF init` so it can initialize backends non-interactively.

### Apply/plan summary output parsing

- **`lib/ci/tacos_summary.py`**: The `applied` property matched `"Terraform will perform the following actions:"` — OpenTofu says `"OpenTofu will perform..."`. Changed to `"will perform the following actions:"` which matches both.

### Test assertions

- **`spec/behaviors/plan_on_push.py`**: Updated init success, actions, and plan-save assertions to be binary-agnostic.
- **`spec/behaviors/apply_on_update.py`**: Same init/actions string fixes.
- **`spec/behaviors/force_unlock_on_happy_path.py`**: Updated unlock success assertion to match both binaries.

## Context

- ops gitignores `.terraform.lock.hcl`, so `-upgrade` is safe (no lock files to preserve)
- All google provider constraints use exact pins (`= 7.15.0`), so `-upgrade` can't drift
- `ops/bin/bootstrap_lib/terragrunt.py` already uses `init -upgrade` locally

https://claude.ai/code/session_01JgkVXFe4wSixMcrRKTEKK1