### PR TITLE
change(acquire): Add debug output for failure in aquire

### DIFF
--- a/lib/tf_lock/lib/acquire.py
+++ b/lib/tf_lock/lib/acquire.py
@@ -56,7 +56,10 @@ async def get_prompt(output: asyncio.StreamReader) -> str:
                 raise
         prompt = ansi_denoise(data)
         if prompt:
-            return prompt.decode("UTF-8")
+            try:
+                return prompt.decode("UTF-8")
+            except UnicodeDecodeError:
+                raise Exception(f"prompt decode failure: {prompt}")
     return ""
 
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "$repo/tacos-gha/lib/tf_lock/tf_lock_acquire.py", line 103, in <module>
    raise SystemExit(main())
                     ^^^^^^
  File "$repo/tacos-gha/lib/tf_lock/tf_lock_acquire.py", line 96, in main
    if ret_code := tf_lock_acquire(path):
                   ^^^^^^^^^^^^^^^^^^^^^
  File "$repo/tacos-gha/lib/tf_lock/tf_lock_acquire.py", line 65, in tf_lock_acquire
    returncode = asyncio.run(acquire(), debug=DEBUG > 0)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "$repo/tacos-gha/lib/tf_lock/lib/acquire.py", line 114, in acquire
    elif (result := prompt.result()).endswith("> "):
                    ^^^^^^^^^^^^^^^
  File "$repo/tacos-gha/lib/tf_lock/lib/acquire.py", line 59, in get_prompt
    return prompt.decode("UTF-8")
           ^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 63: unexpected end of data
```

I see this in edge. want to add more output for debug