### PR TITLE
Merge main into stable (#322)

### DIFF
--- a/lib/tf_lock/lib/acquire.py
+++ b/lib/tf_lock/lib/acquire.py
@@ -56,7 +56,10 @@ async def get_prompt(output: asyncio.StreamReader) -> str:
                 raise
         prompt = ansi_denoise(data)
         if prompt:
-            return prompt.decode("UTF-8")
+            try:
+                return prompt.decode("UTF-8")
+            except UnicodeDecodeError:
+                raise Exception(f"prompt decode failure: {prompt}")
     return ""
 
 


### PR DESCRIPTION
## Summary

Merge `main` into `stable` to release the following change:

### Changes
- **change(acquire): Add debug output for failure in acquire** (#322) — Adds more debug output around the `acquire` prompt decoding to help diagnose a `UnicodeDecodeError` seen in edge when decoding a partial UTF-8 prompt.

## Test plan
- Merge is a clean fast-forward of a single, already-reviewed commit (#322) that only touches `lib/tf_lock/lib/acquire.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)